### PR TITLE
Add ERC165 interface ID for IAccount

### DIFF
--- a/l2/system-contracts/interfaces/IAccount.sol
+++ b/l2/system-contracts/interfaces/IAccount.sol
@@ -15,3 +15,9 @@ interface IAccount {
 
 	function prePaymaster(Transaction calldata _transaction) external payable;
 }
+
+bytes4 constant ERC165_ACCOUNT_INTERFACE_ID = IAccount.validateTransaction.selector ^
+	IAccount.executeTransaction.selector ^
+	IAccount.executeTransactionFromOutside.selector ^
+	IAccount.payForTransaction.selector ^
+	IAccount.prePaymaster.selector;


### PR DESCRIPTION
Adds the ERC165 magic value for `supportsInferface` introspection, in order to determine if a given address is an account.

Having this constant tightly colocated to the interface definition makes it more likely to keep it updated when `IAccount` invariably changes in the future.