### PR TITLE
ci: publish-package tagging and update-contracts pr changes

### DIFF
--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -13,6 +13,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@matterlabs'
       - run: yarn
-      - run: yarn publish --tag ${{ github.event.release.tag_name }} --access public
-        env:
+      - env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_NPM_MATTERLABS_AUTOMATION_TOKEN }}
+        run: |
+          if [[ "${{ github.event.release.target_commitish }}" == "main" ]]; then
+            yarn publish --tag latest --access public
+          elif [[ "${{ github.event.release.target_commitish }}" == "beta" ]]; then
+            yarn publish --tag beta --access public
+          fi

--- a/.github/workflows/update-contracts.yaml
+++ b/.github/workflows/update-contracts.yaml
@@ -43,5 +43,5 @@ jobs:
           gh pr create \
             --title "$(git log -1 --pretty=%B)" \
             --body "Updates contracts from https://github.com/matter-labs/era-contracts/tree/$(git log -1 --pretty=%B | grep -oE '\b([a-f0-9]{40})\b')" \
-            --base main \
+            --base ${{ github.ref_name }} \
             --head $(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
* Changed `publish-package` to set tag based on the branch it runs on (`main` / `beta`).
* Changed `update-contracts` to open PR to the branch it runs on.