### PR TITLE
feat: adds additional methods to foundry package

### DIFF
--- a/.github/workflows/foundry-ci.yaml
+++ b/.github/workflows/foundry-ci.yaml
@@ -8,5 +8,5 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: foundry-rs/foundry-toolchain@v1
-      - run: forge build
+      - uses: dutterbutter/foundry-zksync-toolchain@v1
+      - run: forge build --zksync --zk-enable-eravm-extensions

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ node_modules
 
 # Foundry
 /out
+/zkout
 /cache_forge

--- a/contracts/l2-contracts/L2ContractHelper.sol
+++ b/contracts/l2-contracts/L2ContractHelper.sol
@@ -2,6 +2,7 @@
 // We use a floating point pragma here so it can be used within other projects that interact with the ZKsync ecosystem without using our exact pragma version.
 pragma solidity ^0.8.0;
 
+import {EfficientCall} from "../system-contracts/libraries/EfficientCall.sol";
 import {MalformedBytecode, BytecodeError} from "./errors/L2ContractErrors.sol";
 
 /**
@@ -155,6 +156,105 @@ ICompressor constant COMPRESSOR_CONTRACT = ICompressor(
 IPubdataChunkPublisher constant PUBDATA_CHUNK_PUBLISHER = IPubdataChunkPublisher(
     address(SYSTEM_CONTRACTS_OFFSET + 0x11)
 );
+
+/**
+ * @author Matter Labs
+ * @custom:security-contact security@matterlabs.dev
+ * @notice Helper library for working with L2 contracts on L1.
+ */
+library L2ContractHelper {
+    /// @dev The prefix used to create CREATE2 addresses.
+    bytes32 private constant CREATE2_PREFIX = keccak256("zksyncCreate2");
+
+    /// @notice Sends L2 -> L1 arbitrary-long message through the system contract messenger.
+    /// @param _message Data to be sent to L1.
+    /// @return keccak256 hash of the sent message.
+    function sendMessageToL1(bytes memory _message) internal returns (bytes32) {
+        return L2_MESSENGER.sendToL1(_message);
+    }
+
+    /// @notice Computes the create2 address for a Layer 2 contract.
+    /// @param _sender The address of the contract creator.
+    /// @param _salt The salt value to use in the create2 address computation.
+    /// @param _bytecodeHash The contract bytecode hash.
+    /// @param _constructorInputHash The keccak256 hash of the constructor input data.
+    /// @return The create2 address of the contract.
+    /// NOTE: L2 create2 derivation is different from L1 derivation!
+    function computeCreate2Address(
+        address _sender,
+        bytes32 _salt,
+        bytes32 _bytecodeHash,
+        bytes32 _constructorInputHash
+    ) internal pure returns (address) {
+        bytes32 senderBytes = bytes32(uint256(uint160(_sender)));
+        bytes32 data = keccak256(
+            // solhint-disable-next-line func-named-parameters
+            bytes.concat(CREATE2_PREFIX, senderBytes, _salt, _bytecodeHash, _constructorInputHash)
+        );
+
+        return address(uint160(uint256(data)));
+    }
+
+    /// @notice Validate the bytecode format and calculate its hash.
+    /// @param _bytecode The bytecode to hash.
+    /// @return hashedBytecode The 32-byte hash of the bytecode.
+    /// Note: The function reverts the execution if the bytecode has non expected format:
+    /// - Bytecode bytes length is not a multiple of 32
+    /// - Bytecode bytes length is not less than 2^21 bytes (2^16 words)
+    /// - Bytecode words length is not odd
+    function hashL2BytecodeCalldata(bytes calldata _bytecode) internal view returns (bytes32 hashedBytecode) {
+        // Note that the length of the bytecode must be provided in 32-byte words.
+        if (_bytecode.length % 32 != 0) {
+            revert MalformedBytecode(BytecodeError.Length);
+        }
+
+        uint256 bytecodeLenInWords = _bytecode.length / 32;
+        // bytecode length must be less than 2^16 words
+        if (bytecodeLenInWords >= 2 ** 16) {
+            revert MalformedBytecode(BytecodeError.NumberOfWords);
+        }
+        // bytecode length in words must be odd
+        if (bytecodeLenInWords % 2 == 0) {
+            revert MalformedBytecode(BytecodeError.WordsMustBeOdd);
+        }
+        hashedBytecode =
+            EfficientCall.sha(_bytecode) &
+            0x00000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+        // Setting the version of the hash
+        hashedBytecode = (hashedBytecode | bytes32(uint256(1 << 248)));
+        // Setting the length
+        hashedBytecode = hashedBytecode | bytes32(bytecodeLenInWords << 224);
+    }
+
+    /// @notice Validate the bytecode format and calculate its hash.
+    /// @param _bytecode The bytecode to hash.
+    /// @return hashedBytecode The 32-byte hash of the bytecode.
+    /// Note: The function reverts the execution if the bytecode has non expected format:
+    /// - Bytecode bytes length is not a multiple of 32
+    /// - Bytecode bytes length is not less than 2^21 bytes (2^16 words)
+    /// - Bytecode words length is not odd
+    function hashL2Bytecode(bytes memory _bytecode) internal pure returns (bytes32 hashedBytecode) {
+        // Note that the length of the bytecode must be provided in 32-byte words.
+        if (_bytecode.length % 32 != 0) {
+            revert MalformedBytecode(BytecodeError.Length);
+        }
+
+        uint256 bytecodeLenInWords = _bytecode.length / 32;
+        // bytecode length must be less than 2^16 words
+        if (bytecodeLenInWords >= 2 ** 16) {
+            revert MalformedBytecode(BytecodeError.NumberOfWords);
+        }
+        // bytecode length in words must be odd
+        if (bytecodeLenInWords % 2 == 0) {
+            revert MalformedBytecode(BytecodeError.WordsMustBeOdd);
+        }
+        hashedBytecode = sha256(_bytecode) & 0x00000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+        // Setting the version of the hash
+        hashedBytecode = (hashedBytecode | bytes32(uint256(1 << 248)));
+        // Setting the length
+        hashedBytecode = hashedBytecode | bytes32(bytecodeLenInWords << 224);
+    }
+}
 
 /// @notice Structure used to represent a ZKsync transaction.
 struct Transaction {

--- a/contracts/system-contracts/Constants.sol
+++ b/contracts/system-contracts/Constants.sol
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+// We use a floating point pragma here so it can be used within other projects that interact with the ZKsync ecosystem without using our exact pragma version.
+pragma solidity ^0.8.0;
+
+import {IAccountCodeStorage} from "./interfaces/IAccountCodeStorage.sol";
+import {INonceHolder} from "./interfaces/INonceHolder.sol";
+import {IContractDeployer} from "./interfaces/IContractDeployer.sol";
+import {IKnownCodesStorage} from "./interfaces/IKnownCodesStorage.sol";
+import {IImmutableSimulator} from "./interfaces/IImmutableSimulator.sol";
+import {IBaseToken} from "./interfaces/IBaseToken.sol";
+import {IBridgehub} from "./interfaces/IBridgehub.sol";
+import {IL1Messenger} from "./interfaces/IL1Messenger.sol";
+import {ISystemContext} from "./interfaces/ISystemContext.sol";
+import {ICompressor} from "./interfaces/ICompressor.sol";
+import {IComplexUpgrader} from "./interfaces/IComplexUpgrader.sol";
+import {IBootloaderUtilities} from "./interfaces/IBootloaderUtilities.sol";
+import {IPubdataChunkPublisher} from "./interfaces/IPubdataChunkPublisher.sol";
+import {IMessageRoot} from "./interfaces/IMessageRoot.sol";
+import {ICreate2Factory} from "./interfaces/ICreate2Factory.sol";
+
+/// @dev All the system contracts introduced by ZKsync have their addresses
+/// started from 2^15 in order to avoid collision with Ethereum precompiles.
+uint160 constant SYSTEM_CONTRACTS_OFFSET = 0x8000; // 2^15
+
+/// @dev Unlike the value above, it is not overridden for the purpose of testing and
+/// is identical to the constant value actually used as the system contracts offset on
+/// mainnet.
+uint160 constant REAL_SYSTEM_CONTRACTS_OFFSET = 0x8000;
+
+
+/// @dev All the system contracts must be located in the kernel space,
+/// i.e. their addresses must be below 2^16.
+uint160 constant MAX_SYSTEM_CONTRACT_ADDRESS = 0xffff; // 2^16 - 1
+
+/// @dev The offset from which the built-in, but user space contracts are located.
+uint160 constant USER_CONTRACTS_OFFSET = MAX_SYSTEM_CONTRACT_ADDRESS + 1;
+
+address constant ECRECOVER_SYSTEM_CONTRACT = address(0x01);
+address constant SHA256_SYSTEM_CONTRACT = address(0x02);
+address constant ECADD_SYSTEM_CONTRACT = address(0x06);
+address constant ECMUL_SYSTEM_CONTRACT = address(0x07);
+address constant ECPAIRING_SYSTEM_CONTRACT = address(0x08);
+
+
+/// @dev The number of gas that need to be spent for a single byte of pubdata regardless of the pubdata price.
+/// This variable is used to ensure the following:
+/// - That the long-term storage of the operator is compensated properly.
+/// - That it is not possible that the pubdata counter grows too high without spending proportional amount of computation.
+uint256 constant COMPUTATIONAL_PRICE_FOR_PUBDATA = 80;
+
+/// @dev The maximal possible address of an L1-like precompie. These precompiles maintain the following properties:
+/// - Their extcodehash is EMPTY_STRING_KECCAK
+/// - Their extcodesize is 0 despite having a bytecode formally deployed there.
+uint256 constant CURRENT_MAX_PRECOMPILE_ADDRESS = 0xff;
+
+address payable constant BOOTLOADER_FORMAL_ADDRESS = payable(address(SYSTEM_CONTRACTS_OFFSET + 0x01));
+IAccountCodeStorage constant ACCOUNT_CODE_STORAGE_SYSTEM_CONTRACT = IAccountCodeStorage(
+    address(SYSTEM_CONTRACTS_OFFSET + 0x02)
+);
+INonceHolder constant NONCE_HOLDER_SYSTEM_CONTRACT = INonceHolder(address(SYSTEM_CONTRACTS_OFFSET + 0x03));
+IKnownCodesStorage constant KNOWN_CODE_STORAGE_CONTRACT = IKnownCodesStorage(address(SYSTEM_CONTRACTS_OFFSET + 0x04));
+IImmutableSimulator constant IMMUTABLE_SIMULATOR_SYSTEM_CONTRACT = IImmutableSimulator(
+    address(SYSTEM_CONTRACTS_OFFSET + 0x05)
+);
+IContractDeployer constant DEPLOYER_SYSTEM_CONTRACT = IContractDeployer(address(SYSTEM_CONTRACTS_OFFSET + 0x06));
+IContractDeployer constant REAL_DEPLOYER_SYSTEM_CONTRACT = IContractDeployer(address(REAL_SYSTEM_CONTRACTS_OFFSET + 0x06));
+
+// A contract that is allowed to deploy any codehash
+// on any address. To be used only during an upgrade.
+address constant FORCE_DEPLOYER = address(SYSTEM_CONTRACTS_OFFSET + 0x07);
+IL1Messenger constant L1_MESSENGER_CONTRACT = IL1Messenger(address(SYSTEM_CONTRACTS_OFFSET + 0x08));
+address constant MSG_VALUE_SYSTEM_CONTRACT = address(SYSTEM_CONTRACTS_OFFSET + 0x09);
+
+IBaseToken constant BASE_TOKEN_SYSTEM_CONTRACT = IBaseToken(address(SYSTEM_CONTRACTS_OFFSET + 0x0a));
+IBaseToken constant REAL_BASE_TOKEN_SYSTEM_CONTRACT = IBaseToken(address(REAL_SYSTEM_CONTRACTS_OFFSET + 0x0a));
+
+ICreate2Factory constant L2_CREATE2_FACTORY = ICreate2Factory(address(USER_CONTRACTS_OFFSET));
+address constant L2_ASSET_ROUTER = address(USER_CONTRACTS_OFFSET + 0x03);
+IBridgehub constant L2_BRIDGE_HUB = IBridgehub(address(USER_CONTRACTS_OFFSET + 0x02));
+address constant L2_NATIVE_TOKEN_VAULT_ADDR = address(USER_CONTRACTS_OFFSET + 0x04);
+IMessageRoot constant L2_MESSAGE_ROOT = IMessageRoot(address(USER_CONTRACTS_OFFSET + 0x05));
+// Note, that on its own this contract does not provide much functionality, but having it on a constant address
+// serves as a convenient storage for its bytecode to be accessible via `extcodehash`.
+address constant SLOAD_CONTRACT_ADDRESS = address(USER_CONTRACTS_OFFSET + 0x06);
+
+address constant WRAPPED_BASE_TOKEN_IMPL_ADDRESS = address(USER_CONTRACTS_OFFSET + 0x07);
+
+// Hardcoded because even for tests we should keep the address. (Instead `SYSTEM_CONTRACTS_OFFSET + 0x10`)
+// Precompile call depends on it.
+// And we don't want to mock this contract.
+address constant KECCAK256_SYSTEM_CONTRACT = address(0x8010);
+
+ISystemContext constant SYSTEM_CONTEXT_CONTRACT = ISystemContext(payable(address(SYSTEM_CONTRACTS_OFFSET + 0x0b)));
+ISystemContext constant REAL_SYSTEM_CONTEXT_CONTRACT = ISystemContext(payable(address(REAL_SYSTEM_CONTRACTS_OFFSET + 0x0b)));
+
+IBootloaderUtilities constant BOOTLOADER_UTILITIES = IBootloaderUtilities(address(SYSTEM_CONTRACTS_OFFSET + 0x0c));
+
+// It will be a different value for tests, while shouldn't. But for now, this constant is not used by other contracts, so that's fine.
+address constant EVENT_WRITER_CONTRACT = address(SYSTEM_CONTRACTS_OFFSET + 0x0d);
+
+ICompressor constant COMPRESSOR_CONTRACT = ICompressor(address(SYSTEM_CONTRACTS_OFFSET + 0x0e));
+
+IComplexUpgrader constant COMPLEX_UPGRADER_CONTRACT = IComplexUpgrader(address(SYSTEM_CONTRACTS_OFFSET + 0x0f));
+
+IPubdataChunkPublisher constant PUBDATA_CHUNK_PUBLISHER = IPubdataChunkPublisher(
+    address(SYSTEM_CONTRACTS_OFFSET + 0x11)
+);
+
+/// @dev If the bitwise AND of the extraAbi[2] param when calling the MSG_VALUE_SIMULATOR
+/// is non-zero, the call will be assumed to be a system one.
+uint256 constant MSG_VALUE_SIMULATOR_IS_SYSTEM_BIT = 1;
+
+/// @dev The maximal msg.value that context can have
+uint256 constant MAX_MSG_VALUE = type(uint128).max;
+
+/// @dev Prefix used during derivation of account addresses using CREATE2
+/// @dev keccak256("zksyncCreate2")
+bytes32 constant CREATE2_PREFIX = 0x2020dba91b30cc0006188af794c2fb30dd8520db7e2c088b7fc7c103c00ca494;
+/// @dev Prefix used during derivation of account addresses using CREATE
+/// @dev keccak256("zksyncCreate")
+bytes32 constant CREATE_PREFIX = 0x63bae3a9951d38e8a3fbb7b70909afc1200610fc5bc55ade242f815974674f23;
+
+/// @dev Each state diff consists of 156 bytes of actual data and 116 bytes of unused padding, needed for circuit efficiency.
+uint256 constant STATE_DIFF_ENTRY_SIZE = 272;
+
+enum SystemLogKey {
+    L2_TO_L1_LOGS_TREE_ROOT_KEY,
+    PACKED_BATCH_AND_L2_BLOCK_TIMESTAMP_KEY,
+    CHAINED_PRIORITY_TXN_HASH_KEY,
+    NUMBER_OF_LAYER_1_TXS_KEY,
+    // Note, that it is important that `PREV_BATCH_HASH_KEY` has position
+    // `4` since it is the same as it was in the previous protocol version and
+    // it is the only one that is emitted before the system contracts are upgraded.
+    PREV_BATCH_HASH_KEY,
+    L2_DA_VALIDATOR_OUTPUT_HASH_KEY,
+    USED_L2_DA_VALIDATOR_ADDRESS_KEY,
+    EXPECTED_SYSTEM_CONTRACT_UPGRADE_TX_HASH_KEY
+}
+
+/// @dev The number of leaves in the L2->L1 log Merkle tree.
+/// While formally a tree of any length is acceptable, the node supports only a constant length of 16384 leaves.
+uint256 constant L2_TO_L1_LOGS_MERKLE_TREE_LEAVES = 16_384;
+
+/// @dev The length of the derived key in bytes inside compressed state diffs.
+uint256 constant DERIVED_KEY_LENGTH = 32;
+/// @dev The length of the enum index in bytes inside compressed state diffs.
+uint256 constant ENUM_INDEX_LENGTH = 8;
+/// @dev The length of value in bytes inside compressed state diffs.
+uint256 constant VALUE_LENGTH = 32;
+
+/// @dev The length of the compressed initial storage write in bytes.
+uint256 constant COMPRESSED_INITIAL_WRITE_SIZE = DERIVED_KEY_LENGTH + VALUE_LENGTH;
+/// @dev The length of the compressed repeated storage write in bytes.
+uint256 constant COMPRESSED_REPEATED_WRITE_SIZE = ENUM_INDEX_LENGTH + VALUE_LENGTH;
+
+/// @dev The position from which the initial writes start in the compressed state diffs.
+uint256 constant INITIAL_WRITE_STARTING_POSITION = 4;
+
+/// @dev Each storage diffs consists of the following elements:
+/// [20bytes address][32bytes key][32bytes derived key][8bytes enum index][32bytes initial value][32bytes final value]
+/// @dev The offset of the derived key in a storage diff.
+uint256 constant STATE_DIFF_DERIVED_KEY_OFFSET = 52;
+/// @dev The offset of the enum index in a storage diff.
+uint256 constant STATE_DIFF_ENUM_INDEX_OFFSET = 84;
+/// @dev The offset of the final value in a storage diff.
+uint256 constant STATE_DIFF_FINAL_VALUE_OFFSET = 124;
+
+/// @dev Total number of bytes in a blob. Blob = 4096 field elements * 31 bytes per field element
+/// @dev EIP-4844 defines it as 131_072 but we use 4096 * 31 within our circuits to always fit within a field element
+/// @dev Our circuits will prove that a EIP-4844 blob and our internal blob are the same.
+uint256 constant BLOB_SIZE_BYTES = 126_976;
+
+/// @dev Max number of blobs currently supported
+uint256 constant MAX_NUMBER_OF_BLOBS = 6;

--- a/contracts/system-contracts/SystemContractErrors.sol
+++ b/contracts/system-contracts/SystemContractErrors.sol
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: MIT
+// We use a floating point pragma here so it can be used within other projects that interact with the ZKsync ecosystem without using our exact pragma version.
+pragma solidity ^0.8.0;
+
+// 0x86bb51b8
+error AddressHasNoCode(address);
+// 0xefce78c7
+error CallerMustBeBootloader();
+// 0x9eedbd2b
+error CallerMustBeSystemContract();
+// 0x4f951510
+error CompressionValueAddError(uint256 expected, uint256 actual);
+// 0x1e6aff87
+error CompressionValueTransformError(uint256 expected, uint256 actual);
+// 0xc2ea251e
+error CompressionValueSubError(uint256 expected, uint256 actual);
+// 0x849acb7f
+error CompressorInitialWritesProcessedNotEqual(uint256 expected, uint256 actual);
+// 0x61a6a4b3
+error CompressorEnumIndexNotEqual(uint256 expected, uint256 actual);
+// 0x9be48d8d
+error DerivedKeyNotEqualToCompressedValue(bytes32 expected, bytes32 provided);
+// 0xe223db5e
+error DictionaryDividedByEightNotGreaterThanEncodedDividedByTwo();
+// 0x1c25715b
+error EmptyBytes32();
+// 0xc06d5cb2
+error EncodedAndRealBytecodeChunkNotEqual(uint64 expected, uint64 provided);
+// 0x2bfbfc11
+error EncodedLengthNotFourTimesSmallerThanOriginal();
+// 0xe95a1fbe
+error FailedToChargeGas();
+// 0x1f70c58f
+error FailedToPayOperator();
+// 0x9e4a3c8a
+error HashIsNonZero(bytes32);
+// 0x86302004
+error HashMismatch(bytes32 expected, uint256 actual);
+// 0x4e23d035
+error IndexOutOfBounds();
+// 0x122e73e9
+error IndexSizeError();
+// 0x03eb8b54
+error InsufficientFunds(uint256 required, uint256 actual);
+// 0xae962d4e
+error InvalidCall();
+// 0x8cbd7f8b
+error InvalidCodeHash(CodeHashReason);
+// 0xb4fa3fb3
+error InvalidInput();
+// 0x60b85677
+error InvalidNonceOrderingChange();
+// 0xc6b7f67d
+error InvalidSig(SigField, uint256);
+// 0xf4a271b5
+error Keccak256InvalidReturnData();
+// 0xcea34703
+error MalformedBytecode(BytecodeError);
+// 0xe90aded4
+error NonceAlreadyUsed(address account, uint256 nonce);
+// 0x45ac24a6
+error NonceIncreaseError(uint256 max, uint256 proposed);
+// 0x13595475
+error NonceJumpError();
+// 0x1f2f8478
+error NonceNotUsed(address account, uint256 nonce);
+// 0x760a1568
+error NonEmptyAccount();
+// 0x536ec84b
+error NonEmptyMsgValue();
+// 0xd018e08e
+error NonIncreasingTimestamp();
+// 0x50df6bc3
+error NotAllowedToDeployInKernelSpace();
+// 0x35278d12
+error Overflow();
+// 0xe5ec477a
+error ReconstructionMismatch(PubdataField, bytes32 expected, bytes32 actual);
+// 0x3adb5f1d
+error ShaInvalidReturnData();
+// 0xbd8665e2
+error StateDiffLengthMismatch();
+// 0x71c3da01
+error SystemCallFlagRequired();
+// 0xe0456dfe
+error TooMuchPubdata(uint256 limit, uint256 supplied);
+// 0x8e4a23d6
+error Unauthorized(address);
+// 0x3e5efef9
+error UnknownCodeHash(bytes32);
+// 0x9ba6061b
+error UnsupportedOperation();
+// 0xff15b069
+error UnsupportedPaymasterFlow();
+// 0x17a84415
+error UnsupportedTxType(uint256);
+// 0x626ade30
+error ValueMismatch(uint256 expected, uint256 actual);
+// 0x6818f3f9
+error ZeroNonceError();
+// 0x4f2b5b33
+error SloadContractBytecodeUnknown();
+// 0x43197434
+error PreviousBytecodeUnknown();
+
+// 0x7a47c9a2
+error InvalidChainId();
+
+// 0xc84a0422
+error UpgradeTransactionMustBeFirst();
+
+// 0x543f4c07
+error L2BlockNumberZero();
+
+// 0x702a599f
+error PreviousL2BlockHashIsIncorrect(bytes32 correctPrevBlockHash, bytes32 expectedPrevL2BlockHash);
+
+// 0x2692f507
+error CannotInitializeFirstVirtualBlock();
+
+// 0x5e9ad9b0
+error L2BlockAndBatchTimestampMismatch(uint128 l2BlockTimestamp, uint128 currentBatchTimestamp);
+
+// 0x159a6f2e
+error InconsistentNewBatchTimestamp(uint128 newBatchTimestamp, uint128 lastL2BlockTimestamp);
+
+// 0xdcdfb0da
+error NoVirtualBlocks();
+
+// 0x141d6142
+error CannotReuseL2BlockNumberFromPreviousBatch();
+
+// 0xf34da52d
+error IncorrectSameL2BlockTimestamp(uint128 l2BlockTimestamp, uint128 currentL2BlockTimestamp);
+
+// 0x5822b85d
+error IncorrectSameL2BlockPrevBlockHash(bytes32 expectedPrevL2BlockHash, bytes32 latestL2blockHash);
+
+// 0x6d391091
+error IncorrectVirtualBlockInsideMiniblock();
+
+// 0xdf841e81
+error IncorrectL2BlockHash(bytes32 expectedPrevL2BlockHash, bytes32 pendingL2BlockHash);
+
+// 0x35dbda93
+error NonMonotonicL2BlockTimestamp(uint128 l2BlockTimestamp, uint128 currentL2BlockTimestamp);
+
+// 0x6ad429e8
+error CurrentBatchNumberMustBeGreaterThanZero();
+
+// 0x09c63320
+error TimestampsShouldBeIncremental(uint128 newTimestamp, uint128 previousBatchTimestamp);
+
+// 0x33cb1485
+error ProvidedBatchNumberIsNotCorrect(uint128 previousBatchNumber, uint128 _expectedNewNumber);
+
+// 0xaa957ece
+error CodeOracleCallFailed();
+
+// 0x26772295
+error ReturnedBytecodeDoesNotMatchExpectedHash(bytes32 returnedBytecode, bytes32 expectedBytecodeHash);
+
+// 0x7f08f26b
+error SecondCallShouldHaveCostLessGas(uint256 secondCallCost, uint256 firstCallCost);
+
+// 0xaa016ed2
+error ThirdCallShouldHaveSameGasCostAsSecondCall(uint256 thirdCallCost, uint256 secondCallCost);
+
+// 0xee455381
+error CallToKeccakShouldHaveSucceeded();
+
+// 0x9c9d5e18
+error KeccakReturnDataSizeShouldBe32Bytes(uint256 returnDataSize);
+
+// 0x0c69f92e
+error KeccakResultIsNotCorrect(bytes32 result);
+
+// 0x262f4984
+error KeccakShouldStartWorkingAgain();
+
+// 0x034e49a6
+error KeccakMismatchBetweenNumberOfInputsAndOutputs(uint256 testInputsLength, uint256 expectedOutputsLength);
+
+// 0x92f5b709
+error KeccakHashWasNotCalculatedCorrectly(bytes32 result, bytes32 expectedOutputs);
+
+// 0xbf961a28
+error TransactionFailed();
+
+// 0xdd629f86
+error NotEnoughGas();
+
+// 0xf0b4e88f
+error TooMuchGas();
+
+// 0x8c13f15d
+error InvalidNewL2BlockNumber(uint256 l2BlockNumber);
+
+enum CodeHashReason {
+    NotContractOnConstructor,
+    NotConstructedContract
+}
+
+enum SigField {
+    Length,
+    V,
+    S
+}
+
+enum PubdataField {
+    NumberOfLogs,
+    LogsHash,
+    MsgHash,
+    Bytecode,
+    InputDAFunctionSig,
+    InputLogsHash,
+    InputLogsRootHash,
+    InputMsgsHash,
+    InputBytecodeHash,
+    Offset,
+    Length
+}
+
+enum BytecodeError {
+    Version,
+    NumberOfWords,
+    Length,
+    WordsMustBeOdd,
+    DictionaryLength
+}

--- a/contracts/system-contracts/libraries/EfficientCall.sol
+++ b/contracts/system-contracts/libraries/EfficientCall.sol
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: MIT
+// We use a floating point pragma here so it can be used within other projects that interact with the ZKsync ecosystem without using our exact pragma version.
+pragma solidity ^0.8.0;
+
+import {SystemContractHelper, ADDRESS_MASK} from "./SystemContractHelper.sol";
+import {SystemContractsCaller, CalldataForwardingMode, RAW_FAR_CALL_BY_REF_CALL_ADDRESS, SYSTEM_CALL_BY_REF_CALL_ADDRESS, MSG_VALUE_SIMULATOR_IS_SYSTEM_BIT, MIMIC_CALL_BY_REF_CALL_ADDRESS} from "./SystemContractsCaller.sol";
+import {Utils} from "./Utils.sol";
+import {SHA256_SYSTEM_CONTRACT, KECCAK256_SYSTEM_CONTRACT, MSG_VALUE_SYSTEM_CONTRACT} from "../Constants.sol";
+import {Keccak256InvalidReturnData, ShaInvalidReturnData} from "../SystemContractErrors.sol";
+
+/**
+ * @author Matter Labs
+ * @custom:security-contact security@matterlabs.dev
+ * @notice This library is used to perform ultra-efficient calls using zkEVM-specific features.
+ * @dev EVM calls always accept a memory slice as input and return a memory slice as output.
+ * Therefore, even if the user has a ready-made calldata slice, they still need to copy it to memory
+ * before calling. This is especially inefficient for large inputs (proxies, multi-calls, etc.).
+ * In turn, zkEVM operates over a fat pointer, which is a set of (memory page, offset, start, length) in the memory/calldata/returndata.
+ * This allows forwarding the calldata slice as is, without copying it to memory.
+ * @dev Fat pointer is not just an integer, it is an extended data type supported on the VM level.
+ * zkEVM creates the wellformed fat pointers for all the calldata/returndata regions, later
+ * the contract may manipulate the already created fat pointers to forward a slice of the data, but not
+ * to create new fat pointers!
+ * @dev The allowed operation on fat pointers are:
+ * 1. `ptr.add` - Transforms `ptr.offset` into `ptr.offset + u32(_value)`. If overflow happens then it panics.
+ * 2. `ptr.sub` - Transforms `ptr.offset` into `ptr.offset - u32(_value)`. If underflow happens then it panics.
+ * 3. `ptr.pack` - Do the concatenation between the lowest 128 bits of the pointer itself and the highest 128 bits of `_value`. It is typically used to prepare the ABI for external calls.
+ * 4. `ptr.shrink` - Transforms `ptr.length` into `ptr.length - u32(_shrink)`. If underflow happens then it panics.
+ * @dev The call opcodes accept the fat pointer and change it to its canonical form before passing it to the child call
+ * 1. `ptr.start` is transformed into `ptr.offset + ptr.start`
+ * 2. `ptr.length` is transformed into `ptr.length - ptr.offset`
+ * 3. `ptr.offset` is transformed into `0`
+ */
+library EfficientCall {
+    /// @notice Call the `keccak256` without copying calldata to memory.
+    /// @param _data The preimage data.
+    /// @return The `keccak256` hash.
+    function keccak(bytes calldata _data) internal view returns (bytes32) {
+        bytes memory returnData = staticCall(gasleft(), KECCAK256_SYSTEM_CONTRACT, _data);
+        if (returnData.length != 32) {
+            revert Keccak256InvalidReturnData();
+        }
+        return bytes32(returnData);
+    }
+
+    /// @notice Call the `sha256` precompile without copying calldata to memory.
+    /// @param _data The preimage data.
+    /// @return The `sha256` hash.
+    function sha(bytes calldata _data) internal view returns (bytes32) {
+        bytes memory returnData = staticCall(gasleft(), SHA256_SYSTEM_CONTRACT, _data);
+        if (returnData.length != 32) {
+            revert ShaInvalidReturnData();
+        }
+        return bytes32(returnData);
+    }
+
+    /// @notice Perform a `call` without copying calldata to memory.
+    /// @param _gas The gas to use for the call.
+    /// @param _address The address to call.
+    /// @param _value The `msg.value` to send.
+    /// @param _data The calldata to use for the call.
+    /// @param _isSystem Whether the call should contain the `isSystem` flag.
+    /// @return returnData The copied to memory return data.
+    function call(
+        uint256 _gas,
+        address _address,
+        uint256 _value,
+        bytes calldata _data,
+        bool _isSystem
+    ) internal returns (bytes memory returnData) {
+        bool success = rawCall({_gas: _gas, _address: _address, _value: _value, _data: _data, _isSystem: _isSystem});
+        returnData = _verifyCallResult(success);
+    }
+
+    /// @notice Perform a `staticCall` without copying calldata to memory.
+    /// @param _gas The gas to use for the call.
+    /// @param _address The address to call.
+    /// @param _data The calldata to use for the call.
+    /// @return returnData The copied to memory return data.
+    function staticCall(
+        uint256 _gas,
+        address _address,
+        bytes calldata _data
+    ) internal view returns (bytes memory returnData) {
+        bool success = rawStaticCall(_gas, _address, _data);
+        returnData = _verifyCallResult(success);
+    }
+
+    /// @notice Perform a `delegateCall` without copying calldata to memory.
+    /// @param _gas The gas to use for the call.
+    /// @param _address The address to call.
+    /// @param _data The calldata to use for the call.
+    /// @return returnData The copied to memory return data.
+    function delegateCall(
+        uint256 _gas,
+        address _address,
+        bytes calldata _data
+    ) internal returns (bytes memory returnData) {
+        bool success = rawDelegateCall(_gas, _address, _data);
+        returnData = _verifyCallResult(success);
+    }
+
+    /// @notice Perform a `mimicCall` (a call with custom msg.sender) without copying calldata to memory.
+    /// @param _gas The gas to use for the call.
+    /// @param _address The address to call.
+    /// @param _data The calldata to use for the call.
+    /// @param _whoToMimic The `msg.sender` for the next call.
+    /// @param _isConstructor Whether the call should contain the `isConstructor` flag.
+    /// @param _isSystem Whether the call should contain the `isSystem` flag.
+    /// @return returnData The copied to memory return data.
+    function mimicCall(
+        uint256 _gas,
+        address _address,
+        bytes calldata _data,
+        address _whoToMimic,
+        bool _isConstructor,
+        bool _isSystem
+    ) internal returns (bytes memory returnData) {
+        bool success = rawMimicCall({
+            _gas: _gas,
+            _address: _address,
+            _data: _data,
+            _whoToMimic: _whoToMimic,
+            _isConstructor: _isConstructor,
+            _isSystem: _isSystem
+        });
+
+        returnData = _verifyCallResult(success);
+    }
+
+    /// @notice Perform a `call` without copying calldata to memory.
+    /// @param _gas The gas to use for the call.
+    /// @param _address The address to call.
+    /// @param _value The `msg.value` to send.
+    /// @param _data The calldata to use for the call.
+    /// @param _isSystem Whether the call should contain the `isSystem` flag.
+    /// @return success whether the call was successful.
+    function rawCall(
+        uint256 _gas,
+        address _address,
+        uint256 _value,
+        bytes calldata _data,
+        bool _isSystem
+    ) internal returns (bool success) {
+        if (_value == 0) {
+            _loadFarCallABIIntoActivePtr(_gas, _data, false, _isSystem);
+
+            address callAddr = RAW_FAR_CALL_BY_REF_CALL_ADDRESS;
+            assembly {
+                success := call(_address, callAddr, 0, 0, 0xFFFF, 0, 0)
+            }
+        } else {
+            _loadFarCallABIIntoActivePtr(_gas, _data, false, true);
+
+            // If there is provided `msg.value` call the `MsgValueSimulator` to forward ether.
+            address msgValueSimulator = MSG_VALUE_SYSTEM_CONTRACT;
+            address callAddr = SYSTEM_CALL_BY_REF_CALL_ADDRESS;
+            // We need to supply the mask to the MsgValueSimulator to denote
+            // that the call should be a system one.
+            uint256 forwardMask = _isSystem ? MSG_VALUE_SIMULATOR_IS_SYSTEM_BIT : 0;
+
+            assembly {
+                success := call(msgValueSimulator, callAddr, _value, _address, 0xFFFF, forwardMask, 0)
+            }
+        }
+    }
+
+    /// @notice Perform a `staticCall` without copying calldata to memory.
+    /// @param _gas The gas to use for the call.
+    /// @param _address The address to call.
+    /// @param _data The calldata to use for the call.
+    /// @return success whether the call was successful.
+    function rawStaticCall(uint256 _gas, address _address, bytes calldata _data) internal view returns (bool success) {
+        _loadFarCallABIIntoActivePtr(_gas, _data, false, false);
+
+        address callAddr = RAW_FAR_CALL_BY_REF_CALL_ADDRESS;
+        assembly {
+            success := staticcall(_address, callAddr, 0, 0xFFFF, 0, 0)
+        }
+    }
+
+    /// @notice Perform a `delegatecall` without copying calldata to memory.
+    /// @param _gas The gas to use for the call.
+    /// @param _address The address to call.
+    /// @param _data The calldata to use for the call.
+    /// @return success whether the call was successful.
+    function rawDelegateCall(uint256 _gas, address _address, bytes calldata _data) internal returns (bool success) {
+        _loadFarCallABIIntoActivePtr(_gas, _data, false, false);
+
+        address callAddr = RAW_FAR_CALL_BY_REF_CALL_ADDRESS;
+        assembly {
+            success := delegatecall(_address, callAddr, 0, 0xFFFF, 0, 0)
+        }
+    }
+
+    /// @notice Perform a `mimicCall` (call with custom msg.sender) without copying calldata to memory.
+    /// @param _gas The gas to use for the call.
+    /// @param _address The address to call.
+    /// @param _data The calldata to use for the call.
+    /// @param _whoToMimic The `msg.sender` for the next call.
+    /// @param _isConstructor Whether the call should contain the `isConstructor` flag.
+    /// @param _isSystem Whether the call should contain the `isSystem` flag.
+    /// @return success whether the call was successful.
+    /// @dev If called not in kernel mode, it will result in a revert (enforced by the VM)
+    function rawMimicCall(
+        uint256 _gas,
+        address _address,
+        bytes calldata _data,
+        address _whoToMimic,
+        bool _isConstructor,
+        bool _isSystem
+    ) internal returns (bool success) {
+        _loadFarCallABIIntoActivePtr(_gas, _data, _isConstructor, _isSystem);
+
+        address callAddr = MIMIC_CALL_BY_REF_CALL_ADDRESS;
+        uint256 cleanupMask = ADDRESS_MASK;
+        assembly {
+            // Clearing values before usage in assembly, since Solidity
+            // doesn't do it by default
+            _whoToMimic := and(_whoToMimic, cleanupMask)
+
+            success := call(_address, callAddr, 0, 0, _whoToMimic, 0, 0)
+        }
+    }
+
+    /// @dev Verify that a low-level call was successful, and revert if it wasn't, by bubbling the revert reason.
+    /// @param _success Whether the call was successful.
+    /// @return returnData The copied to memory return data.
+    function _verifyCallResult(bool _success) private pure returns (bytes memory returnData) {
+        if (_success) {
+            uint256 size;
+            assembly {
+                size := returndatasize()
+            }
+
+            returnData = new bytes(size);
+            assembly {
+                returndatacopy(add(returnData, 0x20), 0, size)
+            }
+        } else {
+            propagateRevert();
+        }
+    }
+
+    /// @dev Propagate the revert reason from the current call to the caller.
+    function propagateRevert() internal pure {
+        assembly {
+            let size := returndatasize()
+            returndatacopy(0, 0, size)
+            revert(0, size)
+        }
+    }
+
+    /// @dev Load the far call ABI into active ptr, that will be used for the next call by reference.
+    /// @param _gas The gas to be passed to the call.
+    /// @param _data The calldata to be passed to the call.
+    /// @param _isConstructor Whether the call is a constructor call.
+    /// @param _isSystem Whether the call is a system call.
+    function _loadFarCallABIIntoActivePtr(
+        uint256 _gas,
+        bytes calldata _data,
+        bool _isConstructor,
+        bool _isSystem
+    ) private view {
+        SystemContractHelper.loadCalldataIntoActivePtr();
+
+        uint256 dataOffset;
+        assembly {
+            dataOffset := _data.offset
+        }
+
+        // Safe to cast, offset is never bigger than `type(uint32).max`
+        SystemContractHelper.ptrAddIntoActive(uint32(dataOffset));
+        // Safe to cast, `data.length` is never bigger than `type(uint32).max`
+        uint32 shrinkTo = uint32(msg.data.length - (_data.length + dataOffset));
+        SystemContractHelper.ptrShrinkIntoActive(shrinkTo);
+
+        uint32 gas = Utils.safeCastToU32(_gas);
+        uint256 farCallAbi = SystemContractsCaller.getFarCallABIWithEmptyFatPointer({
+            gasPassed: gas,
+            // Only rollup is supported for now
+            shardId: 0,
+            forwardingMode: CalldataForwardingMode.ForwardFatPointer,
+            isConstructorCall: _isConstructor,
+            isSystemCall: _isSystem
+        });
+        SystemContractHelper.ptrPackIntoActivePtr(farCallAbi);
+    }
+}

--- a/contracts/system-contracts/libraries/SystemContractHelper.sol
+++ b/contracts/system-contracts/libraries/SystemContractHelper.sol
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: MIT
+// We use a floating point pragma here so it can be used within other projects that interact with the ZKsync ecosystem without using our exact pragma version.
+pragma solidity ^0.8.0;
+
+import {MAX_SYSTEM_CONTRACT_ADDRESS, DEPLOYER_SYSTEM_CONTRACT, FORCE_DEPLOYER, KNOWN_CODE_STORAGE_CONTRACT, SLOAD_CONTRACT_ADDRESS} from "../Constants.sol";
+import {ForceDeployment, IContractDeployer} from "../interfaces/IContractDeployer.sol";
+
+import {CalldataForwardingMode, SystemContractsCaller, MIMIC_CALL_CALL_ADDRESS, CALLFLAGS_CALL_ADDRESS, CODE_ADDRESS_CALL_ADDRESS, EVENT_WRITE_ADDRESS, EVENT_INITIALIZE_ADDRESS, GET_EXTRA_ABI_DATA_ADDRESS, LOAD_CALLDATA_INTO_ACTIVE_PTR_CALL_ADDRESS, META_CODE_SHARD_ID_OFFSET, META_CALLER_SHARD_ID_OFFSET, META_SHARD_ID_OFFSET, META_AUX_HEAP_SIZE_OFFSET, META_HEAP_SIZE_OFFSET, META_PUBDATA_PUBLISHED_OFFSET, META_CALL_ADDRESS, PTR_CALLDATA_CALL_ADDRESS, PTR_ADD_INTO_ACTIVE_CALL_ADDRESS, PTR_SHRINK_INTO_ACTIVE_CALL_ADDRESS, PTR_PACK_INTO_ACTIVE_CALL_ADDRESS, PRECOMPILE_CALL_ADDRESS, SET_CONTEXT_VALUE_CALL_ADDRESS, TO_L1_CALL_ADDRESS} from "./SystemContractsCaller.sol";
+import {IndexOutOfBounds, FailedToChargeGas, SloadContractBytecodeUnknown, PreviousBytecodeUnknown} from "../SystemContractErrors.sol";
+
+uint256 constant UINT32_MASK = type(uint32).max;
+uint256 constant UINT64_MASK = type(uint64).max;
+uint256 constant UINT128_MASK = type(uint128).max;
+uint256 constant ADDRESS_MASK = type(uint160).max;
+
+/// @notice NOTE: The `getZkSyncMeta` that is used to obtain this struct will experience a breaking change in 2024.
+struct ZkSyncMeta {
+    uint32 pubdataPublished;
+    uint32 heapSize;
+    uint32 auxHeapSize;
+    uint8 shardId;
+    uint8 callerShardId;
+    uint8 codeShardId;
+}
+
+enum Global {
+    CalldataPtr,
+    CallFlags,
+    ExtraABIData1,
+    ExtraABIData2,
+    ReturndataPtr
+}
+
+/**
+ * @author Matter Labs
+ * @custom:security-contact security@matterlabs.dev
+ * @notice Library used for accessing zkEVM-specific opcodes, needed for the development
+ * of system contracts.
+ * @dev While this library will be eventually available to public, some of the provided
+ * methods won't work for non-system contracts and also breaking changes at short notice are possible.
+ * We do not recommend this library for external use.
+ */
+library SystemContractHelper {
+    /// @notice Send an L2Log to L1.
+    /// @param _isService The `isService` flag.
+    /// @param _key The `key` part of the L2Log.
+    /// @param _value The `value` part of the L2Log.
+    /// @dev The meaning of all these parameters is context-dependent, but they
+    /// have no intrinsic meaning per se.
+    function toL1(bool _isService, bytes32 _key, bytes32 _value) internal {
+        address callAddr = TO_L1_CALL_ADDRESS;
+        assembly {
+            // Ensuring that the type is bool
+            _isService := and(_isService, 1)
+            // This `success` is always 0, but the method always succeeds
+            // (except for the cases when there is not enough gas)
+            // solhint-disable-next-line no-unused-vars
+            let success := call(_isService, callAddr, _key, _value, 0xFFFF, 0, 0)
+        }
+    }
+
+    /// @notice Get address of the currently executed code.
+    /// @dev This allows differentiating between `call` and `delegatecall`.
+    /// During the former `this` and `codeAddress` are the same, while
+    /// during the latter they are not.
+    function getCodeAddress() internal view returns (address addr) {
+        address callAddr = CODE_ADDRESS_CALL_ADDRESS;
+        assembly {
+            addr := staticcall(0, callAddr, 0, 0xFFFF, 0, 0)
+        }
+    }
+
+    /// @notice Provide a compiler hint, by placing calldata fat pointer into virtual `ACTIVE_PTR`,
+    /// that can be manipulated by `ptr.add`/`ptr.sub`/`ptr.pack`/`ptr.shrink` later.
+    /// @dev This allows making a call by forwarding calldata pointer to the child call.
+    /// It is a much more efficient way to forward calldata, than standard EVM bytes copying.
+    function loadCalldataIntoActivePtr() internal view {
+        address callAddr = LOAD_CALLDATA_INTO_ACTIVE_PTR_CALL_ADDRESS;
+        assembly {
+            pop(staticcall(0, callAddr, 0, 0xFFFF, 0, 0))
+        }
+    }
+
+    /// @notice Compiler simulation of the `ptr.pack` opcode for the virtual `ACTIVE_PTR` pointer.
+    /// @dev Do the concatenation between lowest part of `ACTIVE_PTR` and highest part of `_farCallAbi`
+    /// forming packed fat pointer for a far call or ret ABI when necessary.
+    /// Note: Panics if the lowest 128 bits of `_farCallAbi` are not zeroes.
+    function ptrPackIntoActivePtr(uint256 _farCallAbi) internal view {
+        address callAddr = PTR_PACK_INTO_ACTIVE_CALL_ADDRESS;
+        assembly {
+            pop(staticcall(_farCallAbi, callAddr, 0, 0xFFFF, 0, 0))
+        }
+    }
+
+    /// @notice Compiler simulation of the `ptr.add` opcode for the virtual `ACTIVE_PTR` pointer.
+    /// @dev Transforms `ACTIVE_PTR.offset` into `ACTIVE_PTR.offset + u32(_value)`. If overflow happens then it panics.
+    function ptrAddIntoActive(uint32 _value) internal view {
+        address callAddr = PTR_ADD_INTO_ACTIVE_CALL_ADDRESS;
+        uint256 cleanupMask = UINT32_MASK;
+        assembly {
+            // Clearing input params as they are not cleaned by Solidity by default
+            _value := and(_value, cleanupMask)
+            pop(staticcall(_value, callAddr, 0, 0xFFFF, 0, 0))
+        }
+    }
+
+    /// @notice Compiler simulation of the `ptr.shrink` opcode for the virtual `ACTIVE_PTR` pointer.
+    /// @dev Transforms `ACTIVE_PTR.length` into `ACTIVE_PTR.length - u32(_shrink)`. If underflow happens then it panics.
+    function ptrShrinkIntoActive(uint32 _shrink) internal view {
+        address callAddr = PTR_SHRINK_INTO_ACTIVE_CALL_ADDRESS;
+        uint256 cleanupMask = UINT32_MASK;
+        assembly {
+            // Clearing input params as they are not cleaned by Solidity by default
+            _shrink := and(_shrink, cleanupMask)
+            pop(staticcall(_shrink, callAddr, 0, 0xFFFF, 0, 0))
+        }
+    }
+
+    /// @notice packs precompile parameters into one word
+    /// @param _inputMemoryOffset The memory offset in 32-byte words for the input data for calling the precompile.
+    /// @param _inputMemoryLength The length of the input data in words.
+    /// @param _outputMemoryOffset The memory offset in 32-byte words for the output data.
+    /// @param _outputMemoryLength The length of the output data in words.
+    /// @param _perPrecompileInterpreted The constant, the meaning of which is defined separately for
+    /// each precompile. For information, please read the documentation of the precompilecall log in
+    /// the VM.
+    function packPrecompileParams(
+        uint32 _inputMemoryOffset,
+        uint32 _inputMemoryLength,
+        uint32 _outputMemoryOffset,
+        uint32 _outputMemoryLength,
+        uint64 _perPrecompileInterpreted
+    ) internal pure returns (uint256 rawParams) {
+        rawParams = _inputMemoryOffset;
+        rawParams |= uint256(_inputMemoryLength) << 32;
+        rawParams |= uint256(_outputMemoryOffset) << 64;
+        rawParams |= uint256(_outputMemoryLength) << 96;
+        rawParams |= uint256(_perPrecompileInterpreted) << 192;
+    }
+
+    /// @notice Call precompile with given parameters.
+    /// @param _rawParams The packed precompile params. They can be retrieved by
+    /// the `packPrecompileParams` method.
+    /// @param _gasToBurn The number of gas to burn during this call.
+    /// @param _pubdataToSpend The number of pubdata bytes to burn during the call.
+    /// @return success Whether the call was successful.
+    /// @dev The list of currently available precompiles sha256, keccak256, ecrecover.
+    /// NOTE: The precompile type depends on `this` which calls precompile, which means that only
+    /// system contracts corresponding to the list of precompiles above can do `precompileCall`.
+    /// @dev If used not in the `sha256`, `keccak256` or `ecrecover` contracts, it will just burn the gas provided.
+    /// @dev This method is `unsafe` because it does not check whether there is enough gas to burn.
+    function unsafePrecompileCall(
+        uint256 _rawParams,
+        uint32 _gasToBurn,
+        uint32 _pubdataToSpend
+    ) internal view returns (bool success) {
+        address callAddr = PRECOMPILE_CALL_ADDRESS;
+
+        uint256 params = uint256(_gasToBurn) + (uint256(_pubdataToSpend) << 32);
+
+        uint256 cleanupMask = UINT64_MASK;
+        assembly {
+            // Clearing input params as they are not cleaned by Solidity by default
+            params := and(params, cleanupMask)
+            success := staticcall(_rawParams, callAddr, params, 0xFFFF, 0, 0)
+        }
+    }
+
+    /// @notice Set `msg.value` to next far call.
+    /// @param _value The msg.value that will be used for the *next* call.
+    /// @dev If called not in kernel mode, it will result in a revert (enforced by the VM)
+    function setValueForNextFarCall(uint128 _value) internal returns (bool success) {
+        uint256 cleanupMask = UINT128_MASK;
+        address callAddr = SET_CONTEXT_VALUE_CALL_ADDRESS;
+        assembly {
+            // Clearing input params as they are not cleaned by Solidity by default
+            _value := and(_value, cleanupMask)
+            success := call(0, callAddr, _value, 0, 0xFFFF, 0, 0)
+        }
+    }
+
+    /// @notice Initialize a new event.
+    /// @param initializer The event initializing value.
+    /// @param value1 The first topic or data chunk.
+    function eventInitialize(uint256 initializer, uint256 value1) internal {
+        address callAddr = EVENT_INITIALIZE_ADDRESS;
+        assembly {
+            pop(call(initializer, callAddr, value1, 0, 0xFFFF, 0, 0))
+        }
+    }
+
+    /// @notice Continue writing the previously initialized event.
+    /// @param value1 The first topic or data chunk.
+    /// @param value2 The second topic or data chunk.
+    function eventWrite(uint256 value1, uint256 value2) internal {
+        address callAddr = EVENT_WRITE_ADDRESS;
+        assembly {
+            pop(call(value1, callAddr, value2, 0, 0xFFFF, 0, 0))
+        }
+    }
+
+    /// @notice Get the packed representation of the `ZkSyncMeta` from the current context.
+    /// @notice NOTE: The behavior of this function will experience a breaking change in 2024.
+    /// @return meta The packed representation of the ZkSyncMeta.
+    /// @dev The fields in ZkSyncMeta are NOT tightly packed, i.e. there is a special rule on how
+    /// they are packed. For more information, please read the documentation on ZkSyncMeta.
+    function getZkSyncMetaBytes() internal view returns (uint256 meta) {
+        address callAddr = META_CALL_ADDRESS;
+        assembly {
+            meta := staticcall(0, callAddr, 0, 0xFFFF, 0, 0)
+        }
+    }
+
+    /// @notice Returns the bits [offset..offset+size-1] of the meta.
+    /// @param meta Packed representation of the ZkSyncMeta.
+    /// @param offset The offset of the bits.
+    /// @param size The size of the extracted number in bits.
+    /// @return result The extracted number.
+    function extractNumberFromMeta(uint256 meta, uint256 offset, uint256 size) internal pure returns (uint256 result) {
+        // Firstly, we delete all the bits after the field
+        uint256 shifted = (meta << (256 - size - offset));
+        // Then we shift everything back
+        result = (shifted >> (256 - size));
+    }
+
+    /// @notice Given the packed representation of `ZkSyncMeta`, retrieves the number of pubdata
+    /// bytes published in the batch so far.
+    /// @notice NOTE: The behavior of this function will experience a breaking change in 2024.
+    /// @param meta Packed representation of the ZkSyncMeta.
+    /// @return pubdataPublished The amount of pubdata published in the system so far.
+    function getPubdataPublishedFromMeta(uint256 meta) internal pure returns (uint32 pubdataPublished) {
+        pubdataPublished = uint32(extractNumberFromMeta(meta, META_PUBDATA_PUBLISHED_OFFSET, 32));
+    }
+
+    /// @notice Given the packed representation of `ZkSyncMeta`, retrieves the number of the current size
+    /// of the heap in bytes.
+    /// @param meta Packed representation of the ZkSyncMeta.
+    /// @return heapSize The size of the memory in bytes byte.
+    /// @dev The following expression: getHeapSizeFromMeta(getZkSyncMetaBytes()) is
+    /// equivalent to the MSIZE in Solidity.
+    function getHeapSizeFromMeta(uint256 meta) internal pure returns (uint32 heapSize) {
+        heapSize = uint32(extractNumberFromMeta(meta, META_HEAP_SIZE_OFFSET, 32));
+    }
+
+    /// @notice Given the packed representation of `ZkSyncMeta`, retrieves the number of the current size
+    /// of the auxiliary heap in bytes.
+    /// @param meta Packed representation of the ZkSyncMeta.
+    /// @return auxHeapSize The size of the auxiliary memory in bytes byte.
+    /// @dev You can read more on auxiliary memory in the VM1.2 documentation.
+    function getAuxHeapSizeFromMeta(uint256 meta) internal pure returns (uint32 auxHeapSize) {
+        auxHeapSize = uint32(extractNumberFromMeta(meta, META_AUX_HEAP_SIZE_OFFSET, 32));
+    }
+
+    /// @notice Given the packed representation of `ZkSyncMeta`, retrieves the shardId of `this`.
+    /// @param meta Packed representation of the ZkSyncMeta.
+    /// @return shardId The shardId of `this`.
+    /// @dev Currently only shard 0 (zkRollup) is supported.
+    function getShardIdFromMeta(uint256 meta) internal pure returns (uint8 shardId) {
+        shardId = uint8(extractNumberFromMeta(meta, META_SHARD_ID_OFFSET, 8));
+    }
+
+    /// @notice Given the packed representation of `ZkSyncMeta`, retrieves the shardId of
+    /// the msg.sender.
+    /// @param meta Packed representation of the ZkSyncMeta.
+    /// @return callerShardId The shardId of the msg.sender.
+    /// @dev Currently only shard 0 (zkRollup) is supported.
+    function getCallerShardIdFromMeta(uint256 meta) internal pure returns (uint8 callerShardId) {
+        callerShardId = uint8(extractNumberFromMeta(meta, META_CALLER_SHARD_ID_OFFSET, 8));
+    }
+
+    /// @notice Given the packed representation of `ZkSyncMeta`, retrieves the shardId of
+    /// the currently executed code.
+    /// @param meta Packed representation of the ZkSyncMeta.
+    /// @return codeShardId The shardId of the currently executed code.
+    /// @dev Currently only shard 0 (zkRollup) is supported.
+    function getCodeShardIdFromMeta(uint256 meta) internal pure returns (uint8 codeShardId) {
+        codeShardId = uint8(extractNumberFromMeta(meta, META_CODE_SHARD_ID_OFFSET, 8));
+    }
+
+    /// @notice Retrieves the ZkSyncMeta structure.
+    /// @notice NOTE: The behavior of this function will experience a breaking change in 2024.
+    /// @return meta The ZkSyncMeta execution context parameters.
+    function getZkSyncMeta() internal view returns (ZkSyncMeta memory meta) {
+        uint256 metaPacked = getZkSyncMetaBytes();
+        meta.pubdataPublished = getPubdataPublishedFromMeta(metaPacked);
+        meta.heapSize = getHeapSizeFromMeta(metaPacked);
+        meta.auxHeapSize = getAuxHeapSizeFromMeta(metaPacked);
+        meta.shardId = getShardIdFromMeta(metaPacked);
+        meta.callerShardId = getCallerShardIdFromMeta(metaPacked);
+        meta.codeShardId = getCodeShardIdFromMeta(metaPacked);
+    }
+
+    /// @notice Returns the call flags for the current call.
+    /// @return callFlags The bitmask of the callflags.
+    /// @dev Call flags is the value of the first register
+    /// at the start of the call.
+    /// @dev The zero bit of the callFlags indicates whether the call is
+    /// a constructor call. The first bit of the callFlags indicates whether
+    /// the call is a system one.
+    function getCallFlags() internal view returns (uint256 callFlags) {
+        address callAddr = CALLFLAGS_CALL_ADDRESS;
+        assembly {
+            callFlags := staticcall(0, callAddr, 0, 0xFFFF, 0, 0)
+        }
+    }
+
+    /// @notice Returns the current calldata pointer.
+    /// @return ptr The current calldata pointer.
+    /// @dev NOTE: This file is just an integer and it cannot be used
+    /// to forward the calldata to the next calls in any way.
+    function getCalldataPtr() internal view returns (uint256 ptr) {
+        address callAddr = PTR_CALLDATA_CALL_ADDRESS;
+        assembly {
+            ptr := staticcall(0, callAddr, 0, 0xFFFF, 0, 0)
+        }
+    }
+
+    /// @notice Returns the N-th extraAbiParam for the current call.
+    /// @return extraAbiData The value of the N-th extraAbiParam for this call.
+    /// @dev It is equal to the value of the (N+2)-th register
+    /// at the start of the call.
+    function getExtraAbiData(uint256 index) internal view returns (uint256 extraAbiData) {
+        // Note that there are only 10 accessible registers (indices 0-9 inclusively)
+        if (index > 9) {
+            revert IndexOutOfBounds();
+        }
+
+        address callAddr = GET_EXTRA_ABI_DATA_ADDRESS;
+        assembly {
+            extraAbiData := staticcall(index, callAddr, 0, 0xFFFF, 0, 0)
+        }
+    }
+
+    /// @notice Returns whether the current call is a system call.
+    /// @return `true` or `false` based on whether the current call is a system call.
+    function isSystemCall() internal view returns (bool) {
+        uint256 callFlags = getCallFlags();
+        // When the system call is passed, the 2-bit is set to 1
+        return (callFlags & 2) != 0;
+    }
+
+    /// @notice Returns whether the address is a system contract.
+    /// @param _address The address to test
+    /// @return `true` or `false` based on whether the `_address` is a system contract.
+    function isSystemContract(address _address) internal pure returns (bool) {
+        return uint160(_address) <= uint160(MAX_SYSTEM_CONTRACT_ADDRESS);
+    }
+
+    /// @notice Method used for burning a certain amount of gas.
+    /// @param _gasToPay The number of gas to burn.
+    /// @param _pubdataToSpend The number of pubdata bytes to burn during the call.
+    function burnGas(uint32 _gasToPay, uint32 _pubdataToSpend) internal view {
+        bool precompileCallSuccess = unsafePrecompileCall(
+            0, // The precompile parameters are formal ones. We only need the precompile call to burn gas.
+            _gasToPay,
+            _pubdataToSpend
+        );
+        if (!precompileCallSuccess) {
+            revert FailedToChargeGas();
+        }
+    }
+
+    /// @notice Performs a `mimicCall` to an address.
+    /// @param _to The address to call.
+    /// @param _whoToMimic The address to mimic.
+    /// @param _data The data to pass to the call.
+    /// @return success Whether the call was successful.
+    /// @return returndata The return data of the call.
+    function mimicCall(
+        address _to,
+        address _whoToMimic,
+        bytes memory _data
+    ) internal returns (bool success, bytes memory returndata) {
+        // In zkSync, no memory-related values can exceed uint32, so it is safe to convert here
+        uint32 dataStart;
+        uint32 dataLength = uint32(_data.length);
+        assembly {
+            dataStart := add(_data, 0x20)
+        }
+
+        uint256 farCallAbi = SystemContractsCaller.getFarCallABI({
+            dataOffset: 0,
+            memoryPage: 0,
+            dataStart: dataStart,
+            dataLength: dataLength,
+            gasPassed: uint32(gasleft()),
+            shardId: 0,
+            forwardingMode: CalldataForwardingMode.UseHeap,
+            isConstructorCall: false,
+            isSystemCall: false
+        });
+
+        address callAddr = MIMIC_CALL_CALL_ADDRESS;
+        uint256 rtSize;
+        assembly {
+            success := call(_to, callAddr, 0, farCallAbi, _whoToMimic, 0, 0)
+            rtSize := returndatasize()
+        }
+
+        returndata = new bytes(rtSize);
+        assembly {
+            returndatacopy(add(returndata, 0x20), 0, rtSize)
+        }
+    }
+
+    /// @notice Force deploys some bytecode hash to an address
+    /// without invoking the constructor.
+    /// @param _addr The address to force-deploy the bytecodehash to.
+    /// @param _bytecodeHash The bytecode hash to force-deploy.
+    function forceDeployNoConstructor(address _addr, bytes32 _bytecodeHash) internal {
+        ForceDeployment[] memory deployments = new ForceDeployment[](1);
+        deployments[0] = ForceDeployment({
+            bytecodeHash: _bytecodeHash,
+            newAddress: _addr,
+            callConstructor: false,
+            value: 0,
+            input: hex""
+        });
+        mimicCallWithPropagatedRevert(
+            address(DEPLOYER_SYSTEM_CONTRACT),
+            FORCE_DEPLOYER,
+            abi.encodeCall(IContractDeployer.forceDeployOnAddresses, deployments)
+        );
+    }
+
+    /// @notice Performs a `mimicCall` to an address, while ensuring that the call
+    /// was successful
+    /// @param _to The address to call.
+    /// @param _whoToMimic The address to mimic.
+    /// @param _data The data to pass to the call.
+    function mimicCallWithPropagatedRevert(address _to, address _whoToMimic, bytes memory _data) internal {
+        (bool success, bytes memory returnData) = mimicCall(_to, _whoToMimic, _data);
+        if (!success) {
+            // Propagate revert reason
+            assembly {
+                revert(add(returnData, 0x20), returndatasize())
+            }
+        }
+    }
+}

--- a/contracts/system-contracts/libraries/SystemContractsCaller.sol
+++ b/contracts/system-contracts/libraries/SystemContractsCaller.sol
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: MIT
+// We use a floating point pragma here so it can be used within other projects that interact with the ZKsync ecosystem without using our exact pragma version.
+pragma solidity ^0.8.0;
+
+import {MSG_VALUE_SYSTEM_CONTRACT, MSG_VALUE_SIMULATOR_IS_SYSTEM_BIT} from "../Constants.sol";
+import {Utils} from "./Utils.sol";
+
+// Addresses used for the compiler to be replaced with the
+// ZKsync-specific opcodes during the compilation.
+// IMPORTANT: these are just compile-time constants and are used
+// only if used in-place by Yul optimizer.
+address constant TO_L1_CALL_ADDRESS = address((1 << 16) - 1);
+address constant CODE_ADDRESS_CALL_ADDRESS = address((1 << 16) - 2);
+address constant PRECOMPILE_CALL_ADDRESS = address((1 << 16) - 3);
+address constant META_CALL_ADDRESS = address((1 << 16) - 4);
+address constant MIMIC_CALL_CALL_ADDRESS = address((1 << 16) - 5);
+address constant SYSTEM_MIMIC_CALL_CALL_ADDRESS = address((1 << 16) - 6);
+address constant MIMIC_CALL_BY_REF_CALL_ADDRESS = address((1 << 16) - 7);
+address constant SYSTEM_MIMIC_CALL_BY_REF_CALL_ADDRESS = address((1 << 16) - 8);
+address constant RAW_FAR_CALL_CALL_ADDRESS = address((1 << 16) - 9);
+address constant RAW_FAR_CALL_BY_REF_CALL_ADDRESS = address((1 << 16) - 10);
+address constant SYSTEM_CALL_CALL_ADDRESS = address((1 << 16) - 11);
+address constant SYSTEM_CALL_BY_REF_CALL_ADDRESS = address((1 << 16) - 12);
+address constant SET_CONTEXT_VALUE_CALL_ADDRESS = address((1 << 16) - 13);
+address constant SET_PUBDATA_PRICE_CALL_ADDRESS = address((1 << 16) - 14);
+address constant INCREMENT_TX_COUNTER_CALL_ADDRESS = address((1 << 16) - 15);
+address constant PTR_CALLDATA_CALL_ADDRESS = address((1 << 16) - 16);
+address constant CALLFLAGS_CALL_ADDRESS = address((1 << 16) - 17);
+address constant PTR_RETURNDATA_CALL_ADDRESS = address((1 << 16) - 18);
+address constant EVENT_INITIALIZE_ADDRESS = address((1 << 16) - 19);
+address constant EVENT_WRITE_ADDRESS = address((1 << 16) - 20);
+address constant LOAD_CALLDATA_INTO_ACTIVE_PTR_CALL_ADDRESS = address((1 << 16) - 21);
+address constant LOAD_LATEST_RETURNDATA_INTO_ACTIVE_PTR_CALL_ADDRESS = address((1 << 16) - 22);
+address constant PTR_ADD_INTO_ACTIVE_CALL_ADDRESS = address((1 << 16) - 23);
+address constant PTR_SHRINK_INTO_ACTIVE_CALL_ADDRESS = address((1 << 16) - 24);
+address constant PTR_PACK_INTO_ACTIVE_CALL_ADDRESS = address((1 << 16) - 25);
+address constant MULTIPLICATION_HIGH_ADDRESS = address((1 << 16) - 26);
+address constant GET_EXTRA_ABI_DATA_ADDRESS = address((1 << 16) - 27);
+
+// All the offsets are in bits
+uint256 constant META_PUBDATA_PUBLISHED_OFFSET = 0 * 8;
+uint256 constant META_HEAP_SIZE_OFFSET = 8 * 8;
+uint256 constant META_AUX_HEAP_SIZE_OFFSET = 12 * 8;
+uint256 constant META_SHARD_ID_OFFSET = 28 * 8;
+uint256 constant META_CALLER_SHARD_ID_OFFSET = 29 * 8;
+uint256 constant META_CODE_SHARD_ID_OFFSET = 30 * 8;
+
+/// @notice The way to forward the calldata:
+/// - Use the current heap (i.e. the same as on EVM).
+/// - Use the auxiliary heap.
+/// - Forward via a pointer
+/// @dev Note, that currently, users do not have access to the auxiliary
+/// heap and so the only type of forwarding that will be used by the users
+/// are UseHeap and ForwardFatPointer for forwarding a slice of the current calldata
+/// to the next call.
+enum CalldataForwardingMode {
+    UseHeap,
+    ForwardFatPointer,
+    UseAuxHeap
+}
+
+/**
+ * @author Matter Labs
+ * @custom:security-contact security@matterlabs.dev
+ * @notice A library that allows calling contracts with the `isSystem` flag.
+ * @dev It is needed to call ContractDeployer and NonceHolder.
+ */
+library SystemContractsCaller {
+    /// @notice Makes a call with the `isSystem` flag.
+    /// @param gasLimit The gas limit for the call.
+    /// @param to The address to call.
+    /// @param value The value to pass with the transaction.
+    /// @param data The calldata.
+    /// @return success Whether the transaction has been successful.
+    /// @dev Note, that the `isSystem` flag can only be set when calling system contracts.
+    function systemCall(uint32 gasLimit, address to, uint256 value, bytes memory data) internal returns (bool success) {
+        address callAddr = SYSTEM_CALL_CALL_ADDRESS;
+
+        uint32 dataStart;
+        assembly {
+            dataStart := add(data, 0x20)
+        }
+        uint32 dataLength = Utils.safeCastToU32(data.length);
+
+        uint256 farCallAbi = SystemContractsCaller.getFarCallABI({
+            dataOffset: 0,
+            memoryPage: 0,
+            dataStart: dataStart,
+            dataLength: dataLength,
+            gasPassed: gasLimit,
+            // Only rollup is supported for now
+            shardId: 0,
+            forwardingMode: CalldataForwardingMode.UseHeap,
+            isConstructorCall: false,
+            isSystemCall: true
+        });
+
+        if (value == 0) {
+            // Doing the system call directly
+            assembly {
+                success := call(to, callAddr, 0, 0, farCallAbi, 0, 0)
+            }
+        } else {
+            address msgValueSimulator = MSG_VALUE_SYSTEM_CONTRACT;
+            // We need to supply the mask to the MsgValueSimulator to denote
+            // that the call should be a system one.
+            uint256 forwardMask = MSG_VALUE_SIMULATOR_IS_SYSTEM_BIT;
+
+            assembly {
+                success := call(msgValueSimulator, callAddr, value, to, farCallAbi, forwardMask, 0)
+            }
+        }
+    }
+
+    /// @notice Makes a call with the `isSystem` flag.
+    /// @param gasLimit The gas limit for the call.
+    /// @param to The address to call.
+    /// @param value The value to pass with the transaction.
+    /// @param data The calldata.
+    /// @return success Whether the transaction has been successful.
+    /// @return returnData The returndata of the transaction (revert reason in case the transaction has failed).
+    /// @dev Note, that the `isSystem` flag can only be set when calling system contracts.
+    function systemCallWithReturndata(
+        uint32 gasLimit,
+        address to,
+        uint128 value,
+        bytes memory data
+    ) internal returns (bool success, bytes memory returnData) {
+        success = systemCall(gasLimit, to, value, data);
+
+        uint256 size;
+        assembly {
+            size := returndatasize()
+        }
+
+        returnData = new bytes(size);
+        assembly {
+            returndatacopy(add(returnData, 0x20), 0, size)
+        }
+    }
+
+    /// @notice Makes a call with the `isSystem` flag.
+    /// @param gasLimit The gas limit for the call.
+    /// @param to The address to call.
+    /// @param value The value to pass with the transaction.
+    /// @param data The calldata.
+    /// @return returnData The returndata of the transaction. In case the transaction reverts, the error
+    /// bubbles up to the parent frame.
+    /// @dev Note, that the `isSystem` flag can only be set when calling system contracts.
+    function systemCallWithPropagatedRevert(
+        uint32 gasLimit,
+        address to,
+        uint128 value,
+        bytes memory data
+    ) internal returns (bytes memory returnData) {
+        bool success;
+        (success, returnData) = systemCallWithReturndata(gasLimit, to, value, data);
+
+        if (!success) {
+            assembly {
+                let size := mload(returnData)
+                revert(add(returnData, 0x20), size)
+            }
+        }
+    }
+
+    /// @notice Calculates the packed representation of the FarCallABI.
+    /// @param dataOffset Calldata offset in memory. Provide 0 unless using custom pointer.
+    /// @param memoryPage Memory page to use. Provide 0 unless using custom pointer.
+    /// @param dataStart The start of the calldata slice. Provide the offset in memory
+    /// if not using custom pointer.
+    /// @param dataLength The calldata length. Provide the length of the calldata in bytes
+    /// unless using custom pointer.
+    /// @param gasPassed The gas to pass with the call.
+    /// @param shardId Of the account to call. Currently only 0 is supported.
+    /// @param forwardingMode The forwarding mode to use:
+    /// - provide CalldataForwardingMode.UseHeap when using your current memory
+    /// - provide CalldataForwardingMode.ForwardFatPointer when using custom pointer.
+    /// @param isConstructorCall Whether the call will be a call to the constructor
+    /// (ignored when the caller is not a system contract).
+    /// @param isSystemCall Whether the call will have the `isSystem` flag.
+    /// @return farCallAbi The far call ABI.
+    /// @dev The `FarCallABI` has the following structure:
+    /// pub struct FarCallABI {
+    ///     pub memory_quasi_fat_pointer: FatPointer,
+    ///     pub gas_passed: u32,
+    ///     pub shard_id: u8,
+    ///     pub forwarding_mode: FarCallForwardPageType,
+    ///     pub constructor_call: bool,
+    ///     pub to_system: bool,
+    /// }
+    ///
+    /// The FatPointer struct:
+    ///
+    /// pub struct FatPointer {
+    ///     pub offset: u32, // offset relative to `start`
+    ///     pub memory_page: u32, // memory page where slice is located
+    ///     pub start: u32, // absolute start of the slice
+    ///     pub length: u32, // length of the slice
+    /// }
+    ///
+    /// @dev Note, that the actual layout is the following:
+    ///
+    /// [0..32) bits -- the calldata offset
+    /// [32..64) bits -- the memory page to use. Can be left blank in most of the cases.
+    /// [64..96) bits -- the absolute start of the slice
+    /// [96..128) bits -- the length of the slice.
+    /// [128..192) bits -- empty bits.
+    /// [192..224) bits -- gasPassed.
+    /// [224..232) bits -- forwarding_mode
+    /// [232..240) bits -- shard id.
+    /// [240..248) bits -- constructor call flag
+    /// [248..256] bits -- system call flag
+    function getFarCallABI(
+        uint32 dataOffset,
+        uint32 memoryPage,
+        uint32 dataStart,
+        uint32 dataLength,
+        uint32 gasPassed,
+        uint8 shardId,
+        CalldataForwardingMode forwardingMode,
+        bool isConstructorCall,
+        bool isSystemCall
+    ) internal pure returns (uint256 farCallAbi) {
+        // Fill in the call parameter fields
+        farCallAbi = getFarCallABIWithEmptyFatPointer({
+            gasPassed: gasPassed,
+            shardId: shardId,
+            forwardingMode: forwardingMode,
+            isConstructorCall: isConstructorCall,
+            isSystemCall: isSystemCall
+        });
+
+        // Fill in the fat pointer fields
+        farCallAbi |= dataOffset;
+        farCallAbi |= (uint256(memoryPage) << 32);
+        farCallAbi |= (uint256(dataStart) << 64);
+        farCallAbi |= (uint256(dataLength) << 96);
+    }
+
+    /// @notice Calculates the packed representation of the FarCallABI with zero fat pointer fields.
+    /// @param gasPassed The gas to pass with the call.
+    /// @param shardId Of the account to call. Currently only 0 is supported.
+    /// @param forwardingMode The forwarding mode to use:
+    /// - provide CalldataForwardingMode.UseHeap when using your current memory
+    /// - provide CalldataForwardingMode.ForwardFatPointer when using custom pointer.
+    /// @param isConstructorCall Whether the call will be a call to the constructor
+    /// (ignored when the caller is not a system contract).
+    /// @param isSystemCall Whether the call will have the `isSystem` flag.
+    /// @return farCallAbiWithEmptyFatPtr The far call ABI with zero fat pointer fields.
+    function getFarCallABIWithEmptyFatPointer(
+        uint32 gasPassed,
+        uint8 shardId,
+        CalldataForwardingMode forwardingMode,
+        bool isConstructorCall,
+        bool isSystemCall
+    ) internal pure returns (uint256 farCallAbiWithEmptyFatPtr) {
+        farCallAbiWithEmptyFatPtr |= (uint256(gasPassed) << 192);
+        farCallAbiWithEmptyFatPtr |= (uint256(forwardingMode) << 224);
+        farCallAbiWithEmptyFatPtr |= (uint256(shardId) << 232);
+        if (isConstructorCall) {
+            farCallAbiWithEmptyFatPtr |= (1 << 240);
+        }
+        if (isSystemCall) {
+            farCallAbiWithEmptyFatPtr |= (1 << 248);
+        }
+    }
+}

--- a/contracts/system-contracts/libraries/Utils.sol
+++ b/contracts/system-contracts/libraries/Utils.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+// We use a floating point pragma here so it can be used within other projects that interact with the ZKsync ecosystem without using our exact pragma version.
+pragma solidity ^0.8.0;
+
+import {EfficientCall} from "./EfficientCall.sol";
+import {MalformedBytecode, BytecodeError, Overflow} from "../SystemContractErrors.sol";
+
+/**
+ * @author Matter Labs
+ * @custom:security-contact security@matterlabs.dev
+ * @dev Common utilities used in ZKsync system contracts
+ */
+library Utils {
+    /// @dev Bit mask of bytecode hash "isConstructor" marker
+    bytes32 internal constant IS_CONSTRUCTOR_BYTECODE_HASH_BIT_MASK =
+        0x00ff000000000000000000000000000000000000000000000000000000000000;
+
+    /// @dev Bit mask to set the "isConstructor" marker in the bytecode hash
+    bytes32 internal constant SET_IS_CONSTRUCTOR_MARKER_BIT_MASK =
+        0x0001000000000000000000000000000000000000000000000000000000000000;
+
+    function safeCastToU128(uint256 _x) internal pure returns (uint128) {
+        if (_x > type(uint128).max) {
+            revert Overflow();
+        }
+
+        return uint128(_x);
+    }
+
+    function safeCastToU32(uint256 _x) internal pure returns (uint32) {
+        if (_x > type(uint32).max) {
+            revert Overflow();
+        }
+
+        return uint32(_x);
+    }
+
+    function safeCastToU24(uint256 _x) internal pure returns (uint24) {
+        if (_x > type(uint24).max) {
+            revert Overflow();
+        }
+
+        return uint24(_x);
+    }
+
+    /// @return codeLength The bytecode length in bytes
+    function bytecodeLenInBytes(bytes32 _bytecodeHash) internal pure returns (uint256 codeLength) {
+        codeLength = bytecodeLenInWords(_bytecodeHash) << 5; // _bytecodeHash * 32
+    }
+
+    /// @return codeLengthInWords The bytecode length in machine words
+    function bytecodeLenInWords(bytes32 _bytecodeHash) internal pure returns (uint256 codeLengthInWords) {
+        unchecked {
+            codeLengthInWords = uint256(uint8(_bytecodeHash[2])) * 256 + uint256(uint8(_bytecodeHash[3]));
+        }
+    }
+
+    /// @notice Denotes whether bytecode hash corresponds to a contract that already constructed
+    function isContractConstructed(bytes32 _bytecodeHash) internal pure returns (bool) {
+        return _bytecodeHash[1] == 0x00;
+    }
+
+    /// @notice Denotes whether bytecode hash corresponds to a contract that is on constructor or has already been constructed
+    function isContractConstructing(bytes32 _bytecodeHash) internal pure returns (bool) {
+        return _bytecodeHash[1] == 0x01;
+    }
+
+    /// @notice Sets "isConstructor" flag to TRUE for the bytecode hash
+    /// @param _bytecodeHash The bytecode hash for which it is needed to set the constructing flag
+    /// @return The bytecode hash with "isConstructor" flag set to TRUE
+    function constructingBytecodeHash(bytes32 _bytecodeHash) internal pure returns (bytes32) {
+        // Clear the "isConstructor" marker and set it to 0x01.
+        return constructedBytecodeHash(_bytecodeHash) | SET_IS_CONSTRUCTOR_MARKER_BIT_MASK;
+    }
+
+    /// @notice Sets "isConstructor" flag to FALSE for the bytecode hash
+    /// @param _bytecodeHash The bytecode hash for which it is needed to set the constructing flag
+    /// @return The bytecode hash with "isConstructor" flag set to FALSE
+    function constructedBytecodeHash(bytes32 _bytecodeHash) internal pure returns (bytes32) {
+        return _bytecodeHash & ~IS_CONSTRUCTOR_BYTECODE_HASH_BIT_MASK;
+    }
+
+    /// @notice Validate the bytecode format and calculate its hash.
+    /// @param _bytecode The bytecode to hash.
+    /// @return hashedBytecode The 32-byte hash of the bytecode.
+    /// Note: The function reverts the execution if the bytecode has non expected format:
+    /// - Bytecode bytes length is not a multiple of 32
+    /// - Bytecode bytes length is not less than 2^21 bytes (2^16 words)
+    /// - Bytecode words length is not odd
+    function hashL2Bytecode(bytes calldata _bytecode) internal view returns (bytes32 hashedBytecode) {
+        // Note that the length of the bytecode must be provided in 32-byte words.
+        if (_bytecode.length % 32 != 0) {
+            revert MalformedBytecode(BytecodeError.Length);
+        }
+
+        uint256 lengthInWords = _bytecode.length / 32;
+        // bytecode length must be less than 2^16 words
+        if (lengthInWords >= 2 ** 16) {
+            revert MalformedBytecode(BytecodeError.NumberOfWords);
+        }
+        // bytecode length in words must be odd
+        if (lengthInWords % 2 == 0) {
+            revert MalformedBytecode(BytecodeError.WordsMustBeOdd);
+        }
+        hashedBytecode =
+            EfficientCall.sha(_bytecode) &
+            0x00000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+        // Setting the version of the hash
+        hashedBytecode = (hashedBytecode | bytes32(uint256(1 << 248)));
+        // Setting the length
+        hashedBytecode = hashedBytecode | bytes32(lengthInWords << 224);
+    }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,9 +1,18 @@
 [profile.default]
-auto_detect_solc = true
-evm_version = 'cancun'
-optimizer = true
-optimizer-runs = 9999999
-src = 'contracts'
-out = 'out'
-cache_path = 'cache_forge'
-libs = ["lib"]
+auto_detect_solc     = true
+evm_version          = "cancun"
+optimizer            = true
+optimizer-runs       = 9999999
+src                  = "contracts"
+out                  = "out"
+cache_path           = "cache_forge"
+libs                 = ["lib"]
+
+[profile.default.zksync]
+src              = "contracts"
+out              = "zkout"
+libs             = ["lib"]
+compile          = true
+startup          = true
+optimizer        = true
+optimizer_mode   = "3"


### PR DESCRIPTION
### Description

- Methods added `computeCreate2Address`, `systemCallWithPropagatedRevert`, and utility functions for hashing l2 bytecode. These were requested via feedback conversations.
- Constants are nice to have 

Note: removed the function `forcedSload` ([here](https://github.com/matter-labs/era-contracts/blob/f7ecdb91f7941a3be01ce08bf6a2e4a5fb02a8d5/system-contracts/contracts/libraries/SystemContractHelper.sol#L441)) as its dependent on `SloadContract` which does not have floating pragma 