### PR TITLE
feat: add TransactionHelper encodeHash

### DIFF
--- a/contracts/system-contracts/libraries/TransactionHelper.sol
+++ b/contracts/system-contracts/libraries/TransactionHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // We use a floating point pragma here so it can be used within other projects that interact with the ZKsync ecosystem without using our exact pragma version.
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.0;
 
 import {IPaymasterFlow} from "../interfaces/IPaymasterFlow.sol";
 import {BASE_TOKEN_SYSTEM_CONTRACT, BOOTLOADER_FORMAL_ADDRESS} from "../Constants.sol";

--- a/contracts/system-contracts/libraries/TransactionHelper.sol
+++ b/contracts/system-contracts/libraries/TransactionHelper.sol
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: MIT
 // We use a floating point pragma here so it can be used within other projects that interact with the ZKsync ecosystem without using our exact pragma version.
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
+
+import {IPaymasterFlow} from "../interfaces/IPaymasterFlow.sol";
+import {BASE_TOKEN_SYSTEM_CONTRACT, BOOTLOADER_FORMAL_ADDRESS} from "../Constants.sol";
+import {RLPEncoder} from "./RLPEncoder.sol";
+import {EfficientCall} from "./EfficientCall.sol";
+import {UnsupportedTxType, InvalidInput, UnsupportedPaymasterFlow} from "../SystemContractErrors.sol";
 
 /// @dev The type id of ZKsync's EIP-712-signed transaction.
 uint8 constant EIP_712_TX_TYPE = 0x71;
@@ -61,4 +67,305 @@ struct Transaction {
     // Reserved dynamic type for the future use-case. Using it should be avoided,
     // But it is still here, just in case we want to enable some additional functionality.
     bytes reservedDynamic;
+}
+
+/**
+ * @author Matter Labs
+ * @custom:security-contact security@matterlabs.dev
+ * @notice Library is used to help custom accounts to work with common methods for the Transaction type.
+ */
+library TransactionHelper {
+    /// @notice The EIP-712 typehash for the contract's domain
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId)");
+
+    bytes32 internal constant EIP712_TRANSACTION_TYPE_HASH =
+        keccak256(
+            "Transaction(uint256 txType,uint256 from,uint256 to,uint256 gasLimit,uint256 gasPerPubdataByteLimit,uint256 maxFeePerGas,uint256 maxPriorityFeePerGas,uint256 paymaster,uint256 nonce,uint256 value,bytes data,bytes32[] factoryDeps,bytes paymasterInput)"
+        );
+
+    /// @notice Whether the token is Ethereum.
+    /// @param _addr The address of the token
+    /// @return `true` or `false` based on whether the token is Ether.
+    /// @dev This method assumes that address is Ether either if the address is 0 (for convenience)
+    /// or if the address is the address of the L2BaseToken system contract.
+    function isEthToken(uint256 _addr) internal pure returns (bool) {
+        return _addr == uint256(uint160(address(BASE_TOKEN_SYSTEM_CONTRACT))) || _addr == 0;
+    }
+
+    /// @notice Calculate the suggested signed hash of the transaction,
+    /// i.e. the hash that is signed by EOAs and is recommended to be signed by other accounts.
+    function encodeHash(Transaction calldata _transaction) internal view returns (bytes32 resultHash) {
+        if (_transaction.txType == LEGACY_TX_TYPE) {
+            resultHash = _encodeHashLegacyTransaction(_transaction);
+        } else if (_transaction.txType == EIP_712_TX_TYPE) {
+            resultHash = _encodeHashEIP712Transaction(_transaction);
+        } else if (_transaction.txType == EIP_1559_TX_TYPE) {
+            resultHash = _encodeHashEIP1559Transaction(_transaction);
+        } else if (_transaction.txType == EIP_2930_TX_TYPE) {
+            resultHash = _encodeHashEIP2930Transaction(_transaction);
+        } else {
+            // Currently no other transaction types are supported.
+            // Any new transaction types will be processed in a similar manner.
+            revert UnsupportedTxType(_transaction.txType);
+        }
+    }
+
+    /// @notice Encode hash of the ZKsync native transaction type.
+    /// @return keccak256 hash of the EIP-712 encoded representation of transaction
+    function _encodeHashEIP712Transaction(Transaction calldata _transaction) private view returns (bytes32) {
+        bytes32 structHash = keccak256(
+            // solhint-disable-next-line func-named-parameters
+            abi.encode(
+                EIP712_TRANSACTION_TYPE_HASH,
+                _transaction.txType,
+                _transaction.from,
+                _transaction.to,
+                _transaction.gasLimit,
+                _transaction.gasPerPubdataByteLimit,
+                _transaction.maxFeePerGas,
+                _transaction.maxPriorityFeePerGas,
+                _transaction.paymaster,
+                _transaction.nonce,
+                _transaction.value,
+                EfficientCall.keccak(_transaction.data),
+                keccak256(abi.encodePacked(_transaction.factoryDeps)),
+                EfficientCall.keccak(_transaction.paymasterInput)
+            )
+        );
+
+        bytes32 domainSeparator = keccak256(
+            abi.encode(EIP712_DOMAIN_TYPEHASH, keccak256("zkSync"), keccak256("2"), block.chainid)
+        );
+
+        return keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+    }
+
+    /// @notice Encode hash of the legacy transaction type.
+    /// @return keccak256 of the serialized RLP encoded representation of transaction
+    function _encodeHashLegacyTransaction(Transaction calldata _transaction) private view returns (bytes32) {
+        // Hash of legacy transactions are encoded as one of the:
+        // - RLP(nonce, gasPrice, gasLimit, to, value, data, chainId, 0, 0)
+        // - RLP(nonce, gasPrice, gasLimit, to, value, data)
+        //
+        // In this RLP encoding, only the first one above list appears, so we encode each element
+        // inside list and then concatenate the length of all elements with them.
+
+        bytes memory encodedNonce = RLPEncoder.encodeUint256(_transaction.nonce);
+        // Encode `gasPrice` and `gasLimit` together to prevent "stack too deep error".
+        bytes memory encodedGasParam;
+        {
+            bytes memory encodedGasPrice = RLPEncoder.encodeUint256(_transaction.maxFeePerGas);
+            bytes memory encodedGasLimit = RLPEncoder.encodeUint256(_transaction.gasLimit);
+            encodedGasParam = bytes.concat(encodedGasPrice, encodedGasLimit);
+        }
+
+        // "to" field is empty if it is EVM deploy tx
+        bytes memory encodedTo = _transaction.reserved[1] == 1
+            ? bytes(hex"80")
+            : RLPEncoder.encodeAddress(address(uint160(_transaction.to)));
+        bytes memory encodedValue = RLPEncoder.encodeUint256(_transaction.value);
+        // Encode only the length of the transaction data, and not the data itself,
+        // so as not to copy to memory a potentially huge transaction data twice.
+        bytes memory encodedDataLength;
+        {
+            // Safe cast, because the length of the transaction data can't be so large.
+            uint64 txDataLen = uint64(_transaction.data.length);
+            if (txDataLen != 1) {
+                // If the length is not equal to one, then only using the length can it be encoded definitely.
+                encodedDataLength = RLPEncoder.encodeNonSingleBytesLen(txDataLen);
+            } else if (_transaction.data[0] >= 0x80) {
+                // If input is a byte in [0x80, 0xff] range, RLP encoding will concatenates 0x81 with the byte.
+                encodedDataLength = hex"81";
+            }
+            // Otherwise the length is not encoded at all.
+        }
+
+        // Encode `chainId` according to EIP-155, but only if the `chainId` is specified in the transaction.
+        bytes memory encodedChainId;
+        if (_transaction.reserved[0] != 0) {
+            encodedChainId = bytes.concat(RLPEncoder.encodeUint256(block.chainid), hex"80_80");
+        }
+
+        bytes memory encodedListLength;
+        unchecked {
+            uint256 listLength = encodedNonce.length +
+                encodedGasParam.length +
+                encodedTo.length +
+                encodedValue.length +
+                encodedDataLength.length +
+                _transaction.data.length +
+                encodedChainId.length;
+
+            // Safe cast, because the length of the list can't be so large.
+            encodedListLength = RLPEncoder.encodeListLen(uint64(listLength));
+        }
+
+        return
+            keccak256(
+                // solhint-disable-next-line func-named-parameters
+                bytes.concat(
+                    encodedListLength,
+                    encodedNonce,
+                    encodedGasParam,
+                    encodedTo,
+                    encodedValue,
+                    encodedDataLength,
+                    _transaction.data,
+                    encodedChainId
+                )
+            );
+    }
+
+    /// @notice Encode hash of the EIP2930 transaction type.
+    /// @return keccak256 of the serialized RLP encoded representation of transaction
+    function _encodeHashEIP2930Transaction(Transaction calldata _transaction) private view returns (bytes32) {
+        // Hash of EIP2930 transactions is encoded the following way:
+        // H(0x01 || RLP(chain_id, nonce, gas_price, gas_limit, destination, amount, data, access_list))
+        //
+        // Note, that on ZKsync access lists are not supported and should always be empty.
+
+        // Encode all fixed-length params to avoid "stack too deep error"
+        bytes memory encodedFixedLengthParams;
+        {
+            bytes memory encodedChainId = RLPEncoder.encodeUint256(block.chainid);
+            bytes memory encodedNonce = RLPEncoder.encodeUint256(_transaction.nonce);
+            bytes memory encodedGasPrice = RLPEncoder.encodeUint256(_transaction.maxFeePerGas);
+            bytes memory encodedGasLimit = RLPEncoder.encodeUint256(_transaction.gasLimit);
+            // "to" field is empty if it is EVM deploy tx
+            bytes memory encodedTo = _transaction.reserved[1] == 1
+                ? bytes(hex"80")
+                : RLPEncoder.encodeAddress(address(uint160(_transaction.to)));
+            bytes memory encodedValue = RLPEncoder.encodeUint256(_transaction.value);
+            // solhint-disable-next-line func-named-parameters
+            encodedFixedLengthParams = bytes.concat(
+                encodedChainId,
+                encodedNonce,
+                encodedGasPrice,
+                encodedGasLimit,
+                encodedTo,
+                encodedValue
+            );
+        }
+
+        // Encode only the length of the transaction data, and not the data itself,
+        // so as not to copy to memory a potentially huge transaction data twice.
+        bytes memory encodedDataLength;
+        {
+            // Safe cast, because the length of the transaction data can't be so large.
+            uint64 txDataLen = uint64(_transaction.data.length);
+            if (txDataLen != 1) {
+                // If the length is not equal to one, then only using the length can it be encoded definitely.
+                encodedDataLength = RLPEncoder.encodeNonSingleBytesLen(txDataLen);
+            } else if (_transaction.data[0] >= 0x80) {
+                // If input is a byte in [0x80, 0xff] range, RLP encoding will concatenates 0x81 with the byte.
+                encodedDataLength = hex"81";
+            }
+            // Otherwise the length is not encoded at all.
+        }
+
+        // On ZKsync, access lists are always zero length (at least for now).
+        bytes memory encodedAccessListLength = RLPEncoder.encodeListLen(0);
+
+        bytes memory encodedListLength;
+        unchecked {
+            uint256 listLength = encodedFixedLengthParams.length +
+                encodedDataLength.length +
+                _transaction.data.length +
+                encodedAccessListLength.length;
+
+            // Safe cast, because the length of the list can't be so large.
+            encodedListLength = RLPEncoder.encodeListLen(uint64(listLength));
+        }
+
+        return
+            keccak256(
+                // solhint-disable-next-line func-named-parameters
+                bytes.concat(
+                    "\x01",
+                    encodedListLength,
+                    encodedFixedLengthParams,
+                    encodedDataLength,
+                    _transaction.data,
+                    encodedAccessListLength
+                )
+            );
+    }
+
+    /// @notice Encode hash of the EIP1559 transaction type.
+    /// @return keccak256 of the serialized RLP encoded representation of transaction
+    function _encodeHashEIP1559Transaction(Transaction calldata _transaction) private view returns (bytes32) {
+        // Hash of EIP1559 transactions is encoded the following way:
+        // H(0x02 || RLP(chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list))
+        //
+        // Note, that on ZKsync access lists are not supported and should always be empty.
+
+        // Encode all fixed-length params to avoid "stack too deep error"
+        bytes memory encodedFixedLengthParams;
+        {
+            bytes memory encodedChainId = RLPEncoder.encodeUint256(block.chainid);
+            bytes memory encodedNonce = RLPEncoder.encodeUint256(_transaction.nonce);
+            bytes memory encodedMaxPriorityFeePerGas = RLPEncoder.encodeUint256(_transaction.maxPriorityFeePerGas);
+            bytes memory encodedMaxFeePerGas = RLPEncoder.encodeUint256(_transaction.maxFeePerGas);
+            bytes memory encodedGasLimit = RLPEncoder.encodeUint256(_transaction.gasLimit);
+            // "to" field is empty if it is EVM deploy tx
+            bytes memory encodedTo = _transaction.reserved[1] == 1
+                ? bytes(hex"80")
+                : RLPEncoder.encodeAddress(address(uint160(_transaction.to)));
+            bytes memory encodedValue = RLPEncoder.encodeUint256(_transaction.value);
+            // solhint-disable-next-line func-named-parameters
+            encodedFixedLengthParams = bytes.concat(
+                encodedChainId,
+                encodedNonce,
+                encodedMaxPriorityFeePerGas,
+                encodedMaxFeePerGas,
+                encodedGasLimit,
+                encodedTo,
+                encodedValue
+            );
+        }
+
+        // Encode only the length of the transaction data, and not the data itself,
+        // so as not to copy to memory a potentially huge transaction data twice.
+        bytes memory encodedDataLength;
+        {
+            // Safe cast, because the length of the transaction data can't be so large.
+            uint64 txDataLen = uint64(_transaction.data.length);
+            if (txDataLen != 1) {
+                // If the length is not equal to one, then only using the length can it be encoded definitely.
+                encodedDataLength = RLPEncoder.encodeNonSingleBytesLen(txDataLen);
+            } else if (_transaction.data[0] >= 0x80) {
+                // If input is a byte in [0x80, 0xff] range, RLP encoding will concatenates 0x81 with the byte.
+                encodedDataLength = hex"81";
+            }
+            // Otherwise the length is not encoded at all.
+        }
+
+        // On ZKsync, access lists are always zero length (at least for now).
+        bytes memory encodedAccessListLength = RLPEncoder.encodeListLen(0);
+
+        bytes memory encodedListLength;
+        unchecked {
+            uint256 listLength = encodedFixedLengthParams.length +
+                encodedDataLength.length +
+                _transaction.data.length +
+                encodedAccessListLength.length;
+
+            // Safe cast, because the length of the list can't be so large.
+            encodedListLength = RLPEncoder.encodeListLen(uint64(listLength));
+        }
+
+        return
+            keccak256(
+                // solhint-disable-next-line func-named-parameters
+                bytes.concat(
+                    "\x02",
+                    encodedListLength,
+                    encodedFixedLengthParams,
+                    encodedDataLength,
+                    _transaction.data,
+                    encodedAccessListLength
+                )
+            );
+    }
 }

--- a/contracts/system-contracts/libraries/TransactionHelper.sol
+++ b/contracts/system-contracts/libraries/TransactionHelper.sol
@@ -79,10 +79,9 @@ library TransactionHelper {
     bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
         keccak256("EIP712Domain(string name,string version,uint256 chainId)");
 
-    bytes32 internal constant EIP712_TRANSACTION_TYPE_HASH =
-        keccak256(
-            "Transaction(uint256 txType,uint256 from,uint256 to,uint256 gasLimit,uint256 gasPerPubdataByteLimit,uint256 maxFeePerGas,uint256 maxPriorityFeePerGas,uint256 paymaster,uint256 nonce,uint256 value,bytes data,bytes32[] factoryDeps,bytes paymasterInput)"
-        );
+    bytes32 internal constant EIP712_TRANSACTION_TYPE_HASH = keccak256(
+        "Transaction(uint256 txType,uint256 from,uint256 to,uint256 gasLimit,uint256 gasPerPubdataByteLimit,uint256 maxFeePerGas,uint256 maxPriorityFeePerGas,uint256 paymaster,uint256 nonce,uint256 value,bytes data,bytes32[] factoryDeps,bytes paymasterInput)"
+    );
 
     /// @notice Whether the token is Ethereum.
     /// @param _addr The address of the token
@@ -134,9 +133,8 @@ library TransactionHelper {
             )
         );
 
-        bytes32 domainSeparator = keccak256(
-            abi.encode(EIP712_DOMAIN_TYPEHASH, keccak256("zkSync"), keccak256("2"), block.chainid)
-        );
+        bytes32 domainSeparator =
+            keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, keccak256("zkSync"), keccak256("2"), block.chainid));
 
         return keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
     }
@@ -161,9 +159,8 @@ library TransactionHelper {
         }
 
         // "to" field is empty if it is EVM deploy tx
-        bytes memory encodedTo = _transaction.reserved[1] == 1
-            ? bytes(hex"80")
-            : RLPEncoder.encodeAddress(address(uint160(_transaction.to)));
+        bytes memory encodedTo =
+            _transaction.reserved[1] == 1 ? bytes(hex"80") : RLPEncoder.encodeAddress(address(uint160(_transaction.to)));
         bytes memory encodedValue = RLPEncoder.encodeUint256(_transaction.value);
         // Encode only the length of the transaction data, and not the data itself,
         // so as not to copy to memory a potentially huge transaction data twice.
@@ -184,37 +181,31 @@ library TransactionHelper {
         // Encode `chainId` according to EIP-155, but only if the `chainId` is specified in the transaction.
         bytes memory encodedChainId;
         if (_transaction.reserved[0] != 0) {
-            encodedChainId = bytes.concat(RLPEncoder.encodeUint256(block.chainid), hex"80_80");
+            encodedChainId = bytes.concat(RLPEncoder.encodeUint256(block.chainid), hex"8080");
         }
 
         bytes memory encodedListLength;
         unchecked {
-            uint256 listLength = encodedNonce.length +
-                encodedGasParam.length +
-                encodedTo.length +
-                encodedValue.length +
-                encodedDataLength.length +
-                _transaction.data.length +
-                encodedChainId.length;
+            uint256 listLength = encodedNonce.length + encodedGasParam.length + encodedTo.length + encodedValue.length
+                + encodedDataLength.length + _transaction.data.length + encodedChainId.length;
 
             // Safe cast, because the length of the list can't be so large.
             encodedListLength = RLPEncoder.encodeListLen(uint64(listLength));
         }
 
-        return
-            keccak256(
-                // solhint-disable-next-line func-named-parameters
-                bytes.concat(
-                    encodedListLength,
-                    encodedNonce,
-                    encodedGasParam,
-                    encodedTo,
-                    encodedValue,
-                    encodedDataLength,
-                    _transaction.data,
-                    encodedChainId
-                )
-            );
+        return keccak256(
+            // solhint-disable-next-line func-named-parameters
+            bytes.concat(
+                encodedListLength,
+                encodedNonce,
+                encodedGasParam,
+                encodedTo,
+                encodedValue,
+                encodedDataLength,
+                _transaction.data,
+                encodedChainId
+            )
+        );
     }
 
     /// @notice Encode hash of the EIP2930 transaction type.
@@ -238,14 +229,8 @@ library TransactionHelper {
                 : RLPEncoder.encodeAddress(address(uint160(_transaction.to)));
             bytes memory encodedValue = RLPEncoder.encodeUint256(_transaction.value);
             // solhint-disable-next-line func-named-parameters
-            encodedFixedLengthParams = bytes.concat(
-                encodedChainId,
-                encodedNonce,
-                encodedGasPrice,
-                encodedGasLimit,
-                encodedTo,
-                encodedValue
-            );
+            encodedFixedLengthParams =
+                bytes.concat(encodedChainId, encodedNonce, encodedGasPrice, encodedGasLimit, encodedTo, encodedValue);
         }
 
         // Encode only the length of the transaction data, and not the data itself,
@@ -269,27 +254,24 @@ library TransactionHelper {
 
         bytes memory encodedListLength;
         unchecked {
-            uint256 listLength = encodedFixedLengthParams.length +
-                encodedDataLength.length +
-                _transaction.data.length +
-                encodedAccessListLength.length;
+            uint256 listLength = encodedFixedLengthParams.length + encodedDataLength.length + _transaction.data.length
+                + encodedAccessListLength.length;
 
             // Safe cast, because the length of the list can't be so large.
             encodedListLength = RLPEncoder.encodeListLen(uint64(listLength));
         }
 
-        return
-            keccak256(
-                // solhint-disable-next-line func-named-parameters
-                bytes.concat(
-                    "\x01",
-                    encodedListLength,
-                    encodedFixedLengthParams,
-                    encodedDataLength,
-                    _transaction.data,
-                    encodedAccessListLength
-                )
-            );
+        return keccak256(
+            // solhint-disable-next-line func-named-parameters
+            bytes.concat(
+                "\x01",
+                encodedListLength,
+                encodedFixedLengthParams,
+                encodedDataLength,
+                _transaction.data,
+                encodedAccessListLength
+            )
+        );
     }
 
     /// @notice Encode hash of the EIP1559 transaction type.
@@ -346,26 +328,23 @@ library TransactionHelper {
 
         bytes memory encodedListLength;
         unchecked {
-            uint256 listLength = encodedFixedLengthParams.length +
-                encodedDataLength.length +
-                _transaction.data.length +
-                encodedAccessListLength.length;
+            uint256 listLength = encodedFixedLengthParams.length + encodedDataLength.length + _transaction.data.length
+                + encodedAccessListLength.length;
 
             // Safe cast, because the length of the list can't be so large.
             encodedListLength = RLPEncoder.encodeListLen(uint64(listLength));
         }
 
-        return
-            keccak256(
-                // solhint-disable-next-line func-named-parameters
-                bytes.concat(
-                    "\x02",
-                    encodedListLength,
-                    encodedFixedLengthParams,
-                    encodedDataLength,
-                    _transaction.data,
-                    encodedAccessListLength
-                )
-            );
+        return keccak256(
+            // solhint-disable-next-line func-named-parameters
+            bytes.concat(
+                "\x02",
+                encodedListLength,
+                encodedFixedLengthParams,
+                encodedDataLength,
+                _transaction.data,
+                encodedAccessListLength
+            )
+        );
     }
 }


### PR DESCRIPTION
closed #47 

The encodeHash method is used in our smart account templates to get the transaction hash.
This PR enables those contracts to be upgraded to the latest version of this package.